### PR TITLE
Experiment: Borrowing payload

### DIFF
--- a/examples/certificate_client.rs
+++ b/examples/certificate_client.rs
@@ -76,7 +76,7 @@ fn main() {
     builder.set_sound("default");
     builder.set_badge(1u32);
 
-    let payload = builder.build(device_token.as_ref(), options);
+    let payload = builder.build(device_token.as_ref(), &options);
 
     // Send the notification, parse response
     match core.run(client.send(payload)) {

--- a/examples/token_client.rs
+++ b/examples/token_client.rs
@@ -82,7 +82,7 @@ fn main() {
     builder.set_sound("default");
     builder.set_badge(1u32);
 
-    let payload = builder.build(device_token.as_ref(), options);
+    let payload = builder.build(device_token.as_ref(), &options);
 
     // Send the notification, parse response
     match core.run(client.send(payload)) {

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,6 +21,7 @@ use tokio_service::Service;
 use openssl::pkcs12::Pkcs12;
 use std::io::Read;
 use tokio_timer::{Timeout, Timer};
+use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
 pub enum Endpoint {
@@ -47,20 +48,21 @@ impl fmt::Display for Endpoint {
 /// the notification and responds with a status OK. In any other case the future
 /// fails. If APNs gives a reason for the failure, the returned `Err`
 /// holds the response for handling.
-pub struct Client {
+pub struct Client<'a> {
     endpoint: Endpoint,
     signer: Option<Signer>,
     http_client: HttpClient<AlpnConnector>,
     timer: Timer,
+    _marker: PhantomData<Payload<'a>>,
 }
 
-impl Client {
+impl<'a> Client<'a> {
     fn new(
         connector: AlpnConnector,
         signer: Option<Signer>,
         endpoint: Endpoint,
         handle: &Handle,
-    ) -> Client {
+    ) -> Client<'a> {
         let builder = HttpClient::configure()
             .keep_alive_timeout(Some(Duration::from_secs(600)))
             .http2_only()
@@ -71,6 +73,7 @@ impl Client {
             signer: signer,
             endpoint: endpoint,
             timer: Timer::default(),
+            _marker: PhantomData,
         }
     }
 
@@ -79,7 +82,7 @@ impl Client {
         password: &str,
         handle: &Handle,
         endpoint: Endpoint,
-    ) -> Result<Client, Error>
+    ) -> Result<Client<'a>, Error>
     where
         R: Read,
     {
@@ -150,8 +153,8 @@ impl Future for FutureResponse {
     }
 }
 
-impl Service for Client {
-    type Request = Payload;
+impl<'a> Service for Client<'a> {
+    type Request = Payload<'a>;
     type Response = Response;
     type Error = Error;
     type Future = FutureResponse;

--- a/src/client.rs
+++ b/src/client.rs
@@ -103,9 +103,9 @@ impl<'a> Client<'a> {
         pkcs8_pem: R,
         key_id: S,
         team_id: T,
-        handle: &Handle,
+        handle: &'a Handle,
         endpoint: Endpoint,
-    ) -> Result<Client, Error>
+    ) -> Result<Client<'a>, Error>
     where
         S: Into<String>,
         T: Into<String>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -48,21 +48,21 @@ impl fmt::Display for Endpoint {
 /// the notification and responds with a status OK. In any other case the future
 /// fails. If APNs gives a reason for the failure, the returned `Err`
 /// holds the response for handling.
-pub struct Client<'a> {
+pub struct Client<'a, 'b> {
     endpoint: Endpoint,
     signer: Option<Signer>,
     http_client: HttpClient<AlpnConnector>,
     timer: Timer,
-    _marker: PhantomData<Payload<'a>>,
+    _marker: PhantomData<Payload<'a, 'b>>,
 }
 
-impl<'a> Client<'a> {
+impl<'a, 'b> Client<'a, 'b> {
     fn new(
         connector: AlpnConnector,
         signer: Option<Signer>,
         endpoint: Endpoint,
         handle: &Handle,
-    ) -> Client<'a> {
+    ) -> Client<'a, 'b> {
         let builder = HttpClient::configure()
             .keep_alive_timeout(Some(Duration::from_secs(600)))
             .http2_only()
@@ -82,7 +82,7 @@ impl<'a> Client<'a> {
         password: &str,
         handle: &Handle,
         endpoint: Endpoint,
-    ) -> Result<Client<'a>, Error>
+    ) -> Result<Client<'a, 'b>, Error>
     where
         R: Read,
     {
@@ -103,9 +103,9 @@ impl<'a> Client<'a> {
         pkcs8_pem: R,
         key_id: S,
         team_id: T,
-        handle: &'a Handle,
+        handle: &Handle,
         endpoint: Endpoint,
-    ) -> Result<Client<'a>, Error>
+    ) -> Result<Client<'a, 'b>, Error>
     where
         S: Into<String>,
         T: Into<String>,
@@ -153,8 +153,8 @@ impl Future for FutureResponse {
     }
 }
 
-impl<'a> Service for Client<'a> {
-    type Request = Payload<'a>;
+impl<'a, 'b> Service for Client<'a, 'b> {
+    type Request = Payload<'a, 'b>;
     type Response = Response;
     type Error = Error;
     type Future = FutureResponse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //! extern crate tokio_core;
 //! extern crate a2;
 //!
-//! use a2::request::notification::{PlainNotificationBuilder, NotificationBuilder};
+//! use a2::request::notification::{NotificationOptions, PlainNotificationBuilder, NotificationBuilder};
 //! use a2::client::{Client, Endpoint};
 //! use std::fs::File;
 //!
@@ -46,7 +46,8 @@
 //!     builder.set_badge(420);
 //!     builder.set_category("cat1");
 //!     builder.set_sound("ping.flac");
-//!     let payload = builder.build("device-token-from-the-user", Default::default());
+//!     let options = NotificationOptions::default();
+//!     let payload = builder.build("device-token-from-the-user", &options);
 //!
 //!     let mut file = File::open("/path/to/private_key.p8").unwrap();
 //!
@@ -68,7 +69,7 @@
 //! extern crate tokio_core;
 //! extern crate a2;
 //!
-//! use a2::request::notification::{SilentNotificationBuilder, NotificationBuilder};
+//! use a2::request::notification::{NotificationOptions, SilentNotificationBuilder, NotificationBuilder};
 //! use a2::client::{Client, Endpoint};
 //! use std::fs::File;
 //!
@@ -87,8 +88,9 @@
 //!         is_paying_user: false,
 //!     };
 //!
+//!     let options = NotificationOptions::default();
 //!     let mut payload = SilentNotificationBuilder::new()
-//!         .build("device-token-from-the-user", Default::default());
+//!         .build("device-token-from-the-user", &options);
 //!
 //!     payload.add_custom_data("apns_gmbh", &tracking_data).unwrap();
 //!

--- a/src/request/notification/localized.rs
+++ b/src/request/notification/localized.rs
@@ -26,7 +26,7 @@ pub struct LocalizedAlert {
 ///
 /// ```rust
 /// # extern crate a2;
-/// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
+/// # use a2::request::notification::{NotificationOptions, LocalizedNotificationBuilder, NotificationBuilder};
 /// # fn main() {
 /// let mut builder = LocalizedNotificationBuilder::new("Hi there", "What's up?");
 /// builder.set_badge(420);
@@ -40,7 +40,8 @@ pub struct LocalizedAlert {
 /// builder.set_title_loc_args(vec!["herp", "derp"]);
 /// builder.set_loc_key("PAUSE");
 /// builder.set_loc_args(vec!["narf", "derp"]);
-/// let payload = builder.build("device_id", Default::default())
+/// let options = NotificationOptions::default();
+/// let payload = builder.build("device_id", &options)
 ///   .to_json_string().unwrap();
 /// # }
 /// ```
@@ -152,7 +153,11 @@ impl LocalizedNotificationBuilder {
 }
 
 impl NotificationBuilder for LocalizedNotificationBuilder {
-    fn build<'a>(self, device_token: &'a str, options: NotificationOptions) -> Payload<'a> {
+    fn build<'a, 'b>(
+        self,
+        device_token: &'a str,
+        options: &'b NotificationOptions,
+    ) -> Payload<'a, 'b> {
         Payload {
             aps: APS {
                 alert: Some(APSAlert::Localized(self.alert)),
@@ -175,8 +180,9 @@ mod tests {
 
     #[test]
     fn test_localized_notification_with_minimal_required_values() {
+        let options = NotificationOptions::default();
         let payload = LocalizedNotificationBuilder::new("the title", "the body")
-            .build("device-token", Default::default())
+            .build("device-token", &options)
             .to_json_string()
             .unwrap();
 
@@ -209,8 +215,9 @@ mod tests {
         builder.set_loc_key("PAUSE");
         builder.set_loc_args(vec!["narf", "derp"]);
 
+        let options = NotificationOptions::default();
         let payload = builder
-            .build("device-token", Default::default())
+            .build("device-token", &options)
             .to_json_string()
             .unwrap();
 
@@ -258,8 +265,9 @@ mod tests {
             key_struct: SubData { nothing: "here" },
         };
 
+        let options = NotificationOptions::default();
         let mut payload = LocalizedNotificationBuilder::new("the title", "the body")
-            .build("device-token", Default::default());
+            .build("device-token", &options);
 
         payload.add_custom_data("custom", &test_data).unwrap();
 

--- a/src/request/notification/localized.rs
+++ b/src/request/notification/localized.rs
@@ -152,10 +152,7 @@ impl LocalizedNotificationBuilder {
 }
 
 impl NotificationBuilder for LocalizedNotificationBuilder {
-    fn build<S>(self, device_token: S, options: NotificationOptions) -> Payload
-    where
-        S: Into<String>,
-    {
+    fn build<'a>(self, device_token: &'a str, options: NotificationOptions) -> Payload<'a> {
         Payload {
             aps: APS {
                 alert: Some(APSAlert::Localized(self.alert)),
@@ -165,7 +162,7 @@ impl NotificationBuilder for LocalizedNotificationBuilder {
                 category: self.category,
                 mutable_content: Some(self.mutable_content),
             },
-            device_token: device_token.into(),
+            device_token: device_token,
             options: options,
             custom_data: None,
         }

--- a/src/request/notification/mod.rs
+++ b/src/request/notification/mod.rs
@@ -14,5 +14,9 @@ use request::payload::Payload;
 
 pub trait NotificationBuilder {
     /// Generates the request payload to be send with the `Client`.
-    fn build<'a>(self, device_token: &'a str, options: NotificationOptions) -> Payload<'a>;
+    fn build<'a, 'b>(
+        self,
+        device_token: &'a str,
+        options: &'b NotificationOptions,
+    ) -> Payload<'a, 'b>;
 }

--- a/src/request/notification/mod.rs
+++ b/src/request/notification/mod.rs
@@ -14,5 +14,5 @@ use request::payload::Payload;
 
 pub trait NotificationBuilder {
     /// Generates the request payload to be send with the `Client`.
-    fn build<S: Into<String>>(self, device_token: S, options: NotificationOptions) -> Payload;
+    fn build<'a>(self, device_token: &'a str, options: NotificationOptions) -> Payload<'a>;
 }

--- a/src/request/notification/plain.rs
+++ b/src/request/notification/plain.rs
@@ -61,10 +61,7 @@ impl PlainNotificationBuilder {
 }
 
 impl NotificationBuilder for PlainNotificationBuilder {
-    fn build<S>(self, device_token: S, options: NotificationOptions) -> Payload
-    where
-        S: Into<String>,
-    {
+    fn build<'a>(self, device_token: &'a str, options: NotificationOptions) -> Payload<'a> {
         Payload {
             aps: APS {
                 alert: Some(APSAlert::Plain(self.body)),
@@ -74,7 +71,7 @@ impl NotificationBuilder for PlainNotificationBuilder {
                 category: self.category,
                 mutable_content: None,
             },
-            device_token: device_token.into(),
+            device_token: device_token,
             options: options,
             custom_data: None,
         }
@@ -108,8 +105,10 @@ mod tests {
         builder.set_category("cat1");
         builder.set_sound("prööt");
 
+        let device_token = "device-token".to_string();
+
         let payload = builder
-            .build("device-token", Default::default())
+            .build(&device_token, Default::default())
             .to_json_string()
             .unwrap();
 

--- a/src/request/notification/plain.rs
+++ b/src/request/notification/plain.rs
@@ -7,13 +7,14 @@ use request::payload::{APSAlert, Payload, APS};
 ///
 /// ```rust
 /// # extern crate a2;
-/// # use a2::request::notification::{NotificationBuilder, PlainNotificationBuilder};
+/// # use a2::request::notification::{NotificationOptions, NotificationBuilder, PlainNotificationBuilder};
 /// # fn main() {
 /// let mut builder = PlainNotificationBuilder::new("Hi there");
 /// builder.set_badge(420);
 /// builder.set_category("cat1");
 /// builder.set_sound("prööt");
-/// let payload = builder.build("device_id", Default::default())
+/// let options = NotificationOptions::default();
+/// let payload = builder.build("device_id", &options)
 ///    .to_json_string().unwrap();
 /// # }
 /// ```
@@ -61,7 +62,11 @@ impl PlainNotificationBuilder {
 }
 
 impl NotificationBuilder for PlainNotificationBuilder {
-    fn build<'a>(self, device_token: &'a str, options: NotificationOptions) -> Payload<'a> {
+    fn build<'a, 'b>(
+        self,
+        device_token: &'a str,
+        options: &'b NotificationOptions,
+    ) -> Payload<'a, 'b> {
         Payload {
             aps: APS {
                 alert: Some(APSAlert::Plain(self.body)),
@@ -84,8 +89,9 @@ mod tests {
 
     #[test]
     fn test_plain_notification_with_text_only() {
+        let options = NotificationOptions::default();
         let payload = PlainNotificationBuilder::new("kulli")
-            .build("device-token", Default::default())
+            .build("device-token", &options)
             .to_json_string()
             .unwrap();
 
@@ -107,8 +113,9 @@ mod tests {
 
         let device_token = "device-token".to_string();
 
+        let options = NotificationOptions::default();
         let payload = builder
-            .build(&device_token, Default::default())
+            .build(&device_token, &options)
             .to_json_string()
             .unwrap();
 
@@ -146,8 +153,9 @@ mod tests {
             key_struct: SubData { nothing: "here" },
         };
 
+        let options = NotificationOptions::default();
         let mut payload =
-            PlainNotificationBuilder::new("kulli").build("device-token", Default::default());
+            PlainNotificationBuilder::new("kulli").build("device-token", &options);
 
         payload.add_custom_data("custom", &test_data).unwrap();
 

--- a/src/request/notification/silent.rs
+++ b/src/request/notification/silent.rs
@@ -36,10 +36,7 @@ impl SilentNotificationBuilder {
 }
 
 impl NotificationBuilder for SilentNotificationBuilder {
-    fn build<S>(self, device_token: S, options: NotificationOptions) -> Payload
-    where
-        S: Into<String>,
-    {
+    fn build<'a>(self, device_token: &'a str, options: NotificationOptions) -> Payload<'a> {
         Payload {
             aps: APS {
                 alert: None,
@@ -49,7 +46,7 @@ impl NotificationBuilder for SilentNotificationBuilder {
                 category: None,
                 mutable_content: None,
             },
-            device_token: device_token.into(),
+            device_token: device_token,
             options: options,
             custom_data: None,
         }

--- a/src/request/notification/silent.rs
+++ b/src/request/notification/silent.rs
@@ -10,14 +10,15 @@ use request::payload::{Payload, APS};
 /// ```rust
 /// # extern crate a2;
 /// # use std::collections::HashMap;
-/// # use a2::request::notification::{NotificationBuilder, SilentNotificationBuilder};
+/// # use a2::request::notification::{NotificationOptions, NotificationBuilder, SilentNotificationBuilder};
 /// # fn main() {
 /// let mut test_data = HashMap::new();
 /// test_data.insert("a", "value");
 /// test_data.insert("another", "value");
 ///
+/// let options = NotificationOptions::default();
 /// let mut payload = SilentNotificationBuilder::new()
-///    .build("device_id", Default::default());
+///    .build("device_id", &options);
 ///
 /// payload.add_custom_data("custom", &test_data);
 /// payload.to_json_string().unwrap();
@@ -36,7 +37,11 @@ impl SilentNotificationBuilder {
 }
 
 impl NotificationBuilder for SilentNotificationBuilder {
-    fn build<'a>(self, device_token: &'a str, options: NotificationOptions) -> Payload<'a> {
+    fn build<'a, 'b>(
+        self,
+        device_token: &'a str,
+        options: &'b NotificationOptions,
+    ) -> Payload<'a, 'b> {
         Payload {
             aps: APS {
                 alert: None,
@@ -60,8 +65,9 @@ mod tests {
 
     #[test]
     fn test_silent_notification_with_no_content() {
+        let options = NotificationOptions::default();
         let payload = SilentNotificationBuilder::new()
-            .build("device-token", Default::default())
+            .build("device-token", &options)
             .to_json_string()
             .unwrap();
 
@@ -96,8 +102,9 @@ mod tests {
             key_struct: SubData { nothing: "here" },
         };
 
+        let options = NotificationOptions::default();
         let mut payload =
-            SilentNotificationBuilder::new().build("device-token", Default::default());
+            SilentNotificationBuilder::new().build("device-token", &options);
 
         payload.add_custom_data("custom", &test_data).unwrap();
 
@@ -124,8 +131,9 @@ mod tests {
         test_data.insert("key_str", "foo");
         test_data.insert("key_str2", "bar");
 
+        let options = NotificationOptions::default();
         let mut payload =
-            SilentNotificationBuilder::new().build("device-token", Default::default());
+            SilentNotificationBuilder::new().build("device-token", &options);
 
         payload.add_custom_data("custom", &test_data).unwrap();
 

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -8,18 +8,18 @@ use erased_serde::Serialize;
 
 /// The data and options for a push notification.
 #[derive(Debug, Clone)]
-pub struct Payload {
+pub struct Payload<'a> {
     /// Send options
     pub options: NotificationOptions,
     /// The token for the receiving device
-    pub device_token: String,
+    pub device_token: &'a str,
     /// The pre-defined notification payload
     pub aps: APS,
     /// Application specific payload
     pub custom_data: Option<HashMap<String, Value>>,
 }
 
-impl Payload {
+impl<'a> Payload<'a> {
     /// Client-specific custom data to be added in the payload.
     pub fn add_custom_data<S: Into<String>>(
         &mut self,

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -8,9 +8,9 @@ use erased_serde::Serialize;
 
 /// The data and options for a push notification.
 #[derive(Debug, Clone)]
-pub struct Payload<'a> {
+pub struct Payload<'a, 'b> {
     /// Send options
-    pub options: NotificationOptions,
+    pub options: &'b NotificationOptions,
     /// The token for the receiving device
     pub device_token: &'a str,
     /// The pre-defined notification payload
@@ -19,7 +19,7 @@ pub struct Payload<'a> {
     pub custom_data: Option<HashMap<String, Value>>,
 }
 
-impl<'a> Payload<'a> {
+impl<'a, 'b> Payload<'a, 'b> {
     /// Client-specific custom data to be added in the payload.
     pub fn add_custom_data<S: Into<String>>(
         &mut self,


### PR DESCRIPTION
As discussed in #8, this is a first attempt at having less owned data in the payload.

@pimeys right now this only considers a single field (the device token). If you agree with the general approach I can try to expand this to other strings.