### PR TITLE
Remove bunch of allocations from the builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## v0.3.0
+
+- Convert the API to not clone the input data, using references until
+  converting to JSON, remove tokio-service dependency
+  [#25](https://github.com/pimeys/a2/pull/25)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a2"
-version = "0.2.3"
+version = "0.3.0"
 authors = [
   "Julius de Bruijn <julius.debruijn@360dialog.com>",
   "Sergey Tkachenko <seriy.tkachenko@gmail.com>", 
@@ -23,7 +23,6 @@ rustls = "0.12"
 futures = "0.1"
 tokio = "0.1"
 tokio-io = "0.1"
-tokio-service = "0.1"
 tokio-rustls = "0.5"
 tokio-timer = "0.1"
 http = "0.1"

--- a/examples/certificate_client.rs
+++ b/examples/certificate_client.rs
@@ -70,21 +70,21 @@ fn main() {
     let client = Client::certificate(&mut certificate, &password, endpoint).unwrap();
 
     let options = NotificationOptions {
-        apns_topic: topic,
+        apns_topic: topic.as_ref().map(|s| &**s),
         ..Default::default()
     };
 
     // Notification payload
-    let mut builder = PlainNotificationBuilder::new(message);
+    let mut builder = PlainNotificationBuilder::new(message.as_ref());
     builder.set_sound("default");
     builder.set_badge(1u32);
 
     let payload = builder.build(device_token.as_ref(), options);
+    let sending = client.send(payload);
 
     // Send the notification, parse response
     tokio::run(lazy(move || {
-        client
-            .send(payload)
+        sending
             .map(|response| {
                 println!("Sent: {:?}", response);
             })

--- a/examples/token_client.rs
+++ b/examples/token_client.rs
@@ -78,21 +78,21 @@ fn main() {
     ).unwrap();
 
     let options = NotificationOptions {
-        apns_topic: topic,
+        apns_topic: topic.as_ref().map(|s| &**s),
         ..Default::default()
     };
 
     // Notification payload
-    let mut builder = PlainNotificationBuilder::new(message);
+    let mut builder = PlainNotificationBuilder::new(message.as_ref());
     builder.set_sound("default");
     builder.set_badge(1u32);
 
     let payload = builder.build(device_token.as_ref(), options);
+    let sending = client.send(payload);
 
     // Send the notification, parse response
     tokio::run(lazy(move || {
-        client
-            .send(payload)
+        sending
             .map(|response| {
                 println!("Sent: {:?}", response);
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,9 +111,10 @@
 //!         "Correct Horse Battery Stable",
 //!         Endpoint::Production).unwrap();
 //!
+//!     let sending = client.send(payload);
+//!
 //!     tokio::run(lazy(move || {
-//!         client
-//!             .send(payload)
+//!         sending
 //!             .map(|response| {
 //!                 println!("Sent: {:?}", response);
 //!             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,7 +153,6 @@ extern crate time;
 extern crate tokio;
 extern crate tokio_io;
 extern crate tokio_rustls;
-extern crate tokio_service;
 extern crate tokio_timer;
 extern crate webpki;
 extern crate webpki_roots;

--- a/src/request/notification/mod.rs
+++ b/src/request/notification/mod.rs
@@ -12,7 +12,7 @@ pub use self::options::{CollapseId, NotificationOptions, Priority};
 
 use request::payload::Payload;
 
-pub trait NotificationBuilder {
+pub trait NotificationBuilder<'a> {
     /// Generates the request payload to be send with the `Client`.
-    fn build<S: Into<String>>(self, device_token: S, options: NotificationOptions) -> Payload;
+    fn build(self, device_token: &'a str, options: NotificationOptions<'a>) -> Payload<'a>;
 }

--- a/src/request/notification/options.rs
+++ b/src/request/notification/options.rs
@@ -2,31 +2,30 @@ use error::Error;
 use std::fmt;
 
 #[derive(Debug, Clone)]
-pub struct CollapseId {
-    pub value: String,
+pub struct CollapseId<'a> {
+    pub value: &'a str,
 }
 
 /// A collapse-id container. Will not allow bigger id's than 64 bytes.
-impl CollapseId {
-    pub fn new<S: Into<String>>(value: S) -> Result<CollapseId, Error> {
-        let s = value.into();
-        if s.len() > 64 {
+impl<'a> CollapseId<'a> {
+    pub fn new(value: &'a str) -> Result<CollapseId<'a>, Error> {
+        if value.len() > 64 {
             Err(Error::InvalidOptions(String::from(
                 "The collapse-id is too big. Maximum 64 bytes.",
             )))
         } else {
-            Ok(CollapseId { value: s })
+            Ok(CollapseId { value: value })
         }
     }
 }
 
 /// Headers to specify options to the notification.
 #[derive(Debug, Clone)]
-pub struct NotificationOptions {
+pub struct NotificationOptions<'a> {
     /// A canonical UUID that identifies the notification. If there is an error
     /// sending the notification, APNs uses this value to identify the
     /// notification to your server.
-    pub apns_id: Option<String>,
+    pub apns_id: Option<&'a str>,
 
     /// A UNIX epoch date expressed in seconds (UTC). This header identifies the
     /// date when the notification is no longer valid and can be discarded.
@@ -55,16 +54,16 @@ pub struct NotificationOptions {
     /// If you are using a provider token instead of a certificate, you must
     /// specify a value for this request header. The topic you provide should be
     /// provisioned for the your team named in your developer account.
-    pub apns_topic: Option<String>,
+    pub apns_topic: Option<&'a str>,
 
     /// Multiple notifications with the same collapse identifier are displayed to the
     /// user as a single notification. The value of this key must not exceed 64
     /// bytes.
-    pub apns_collapse_id: Option<CollapseId>,
+    pub apns_collapse_id: Option<CollapseId<'a>>,
 }
 
-impl Default for NotificationOptions {
-    fn default() -> NotificationOptions {
+impl<'a> Default for NotificationOptions<'a> {
+    fn default() -> NotificationOptions<'a> {
         NotificationOptions {
             apns_id: None,
             apns_expiration: None,
@@ -109,7 +108,7 @@ mod tests {
     #[test]
     fn test_collapse_id_under_64_chars() {
         let collapse_id = CollapseId::new("foo").unwrap();
-        assert_eq!(String::from("foo"), collapse_id.value);
+        assert_eq!("foo", collapse_id.value);
     }
 
     #[test]

--- a/src/request/notification/plain.rs
+++ b/src/request/notification/plain.rs
@@ -1,5 +1,6 @@
 use request::notification::{NotificationBuilder, NotificationOptions};
 use request::payload::{APSAlert, Payload, APS};
+use std::collections::BTreeMap;
 
 /// A builder to create a simple APNs notification payload.
 ///
@@ -17,20 +18,18 @@ use request::payload::{APSAlert, Payload, APS};
 ///    .to_json_string().unwrap();
 /// # }
 /// ```
-pub struct PlainNotificationBuilder {
-    body: String,
+pub struct PlainNotificationBuilder<'a> {
+    body: &'a str,
     badge: Option<u32>,
-    sound: Option<String>,
-    category: Option<String>,
+    sound: Option<&'a str>,
+    category: Option<&'a str>,
 }
 
-impl PlainNotificationBuilder {
-    pub fn new<S>(body: S) -> PlainNotificationBuilder
-    where
-        S: Into<String>,
+impl<'a> PlainNotificationBuilder<'a> {
+    pub fn new(body: &'a str) -> PlainNotificationBuilder<'a>
     {
         PlainNotificationBuilder {
-            body: body.into(),
+            body: body,
             badge: None,
             sound: None,
             category: None,
@@ -38,32 +37,30 @@ impl PlainNotificationBuilder {
     }
 
     /// A number to show on a badge on top of the app icon.
-    pub fn set_badge(&mut self, badge: u32) {
+    pub fn set_badge(&mut self, badge: u32) -> &mut Self
+    {
         self.badge = Some(badge);
+        self
     }
 
     /// File name of the custom sound to play when receiving the notification.
-    pub fn set_sound<S>(&mut self, sound: S)
-    where
-        S: Into<String>,
+    pub fn set_sound(&mut self, sound: &'a str) -> &mut Self
     {
         self.sound = Some(sound.into());
+        self
     }
 
     /// When a notification includes the category key, the system displays the
     /// actions for that category as buttons in the banner or alert interface.
-    pub fn set_category<S>(&mut self, category: S)
-    where
-        S: Into<String>,
+    pub fn set_category(&mut self, category: &'a str) -> &mut Self
     {
-        self.category = Some(category.into());
+        self.category = Some(category);
+        self
     }
 }
 
-impl NotificationBuilder for PlainNotificationBuilder {
-    fn build<S>(self, device_token: S, options: NotificationOptions) -> Payload
-    where
-        S: Into<String>,
+impl<'a> NotificationBuilder<'a> for PlainNotificationBuilder<'a> {
+    fn build(self, device_token: &'a str, options: NotificationOptions<'a>) -> Payload<'a>
     {
         Payload {
             aps: APS {
@@ -74,9 +71,9 @@ impl NotificationBuilder for PlainNotificationBuilder {
                 category: self.category,
                 mutable_content: None,
             },
-            device_token: device_token.into(),
+            device_token: device_token,
             options: options,
-            custom_data: None,
+            data: BTreeMap::new(),
         }
     }
 }
@@ -155,9 +152,6 @@ mod tests {
         let payload_json = payload.to_json_string().unwrap();
 
         let expected_payload = json!({
-            "aps": {
-                "alert": "kulli",
-            },
             "custom": {
                 "key_str": "foo",
                 "key_num": 42,
@@ -165,6 +159,9 @@ mod tests {
                 "key_struct": {
                     "nothing": "here"
                 }
+            },
+            "aps": {
+                "alert": "kulli",
             }
         }).to_string();
 

--- a/src/request/notification/silent.rs
+++ b/src/request/notification/silent.rs
@@ -1,5 +1,6 @@
 use request::notification::{NotificationBuilder, NotificationOptions};
 use request::payload::{Payload, APS};
+use std::collections::BTreeMap;
 
 /// A builder to create an APNs silent notification payload which can be used to
 /// send custom data to the user's phone if the user hasn't been running the app
@@ -35,10 +36,8 @@ impl SilentNotificationBuilder {
     }
 }
 
-impl NotificationBuilder for SilentNotificationBuilder {
-    fn build<S>(self, device_token: S, options: NotificationOptions) -> Payload
-    where
-        S: Into<String>,
+impl<'a> NotificationBuilder<'a> for SilentNotificationBuilder {
+    fn build(self, device_token: &'a str, options: NotificationOptions<'a>) -> Payload<'a>
     {
         Payload {
             aps: APS {
@@ -49,9 +48,9 @@ impl NotificationBuilder for SilentNotificationBuilder {
                 category: None,
                 mutable_content: None,
             },
-            device_token: device_token.into(),
+            device_token: device_token,
             options: options,
-            custom_data: None,
+            data: BTreeMap::new(),
         }
     }
 }
@@ -59,7 +58,7 @@ impl NotificationBuilder for SilentNotificationBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_silent_notification_with_no_content() {
@@ -123,7 +122,7 @@ mod tests {
 
     #[test]
     fn test_silent_notification_with_custom_hashmap() {
-        let mut test_data = HashMap::new();
+        let mut test_data = BTreeMap::new();
         test_data.insert("key_str", "foo");
         test_data.insert("key_str2", "bar");
 


### PR DESCRIPTION
This breaks the api a bit if somebody used Strings. Now we allocate a new string only when creating the result JSON. To have this I needed remove the implementation for `Service` trait to have somehow sane lifetime requirements for the `Client`. If anybody depended on the Service, I'm not merging this right away and need to think of something.

This should bump the version to 0.3.0 when released, but first we're running some tests how much faster we get with these changes.

h0x @dbrgn 