### PR TITLE
Fix token_client example not building due to unresolvable `as_ref()`.

### DIFF
--- a/examples/token_client.rs
+++ b/examples/token_client.rs
@@ -65,12 +65,7 @@ fn main() {
     };
 
     // Connecting to APNs
-    let client = Client::token(
-        &mut private_key,
-        key_id.as_ref(),
-        team_id.as_ref(),
-        endpoint,
-    ).unwrap();
+    let client = Client::token(&mut private_key, key_id, team_id, endpoint).unwrap();
 
     let options = NotificationOptions {
         apns_topic: topic.as_ref().map(|s| &**s),


### PR DESCRIPTION
`Client::token()` accepts `Into<String>` anyway so `as_ref()` wasn't super useful.