### PR TITLE
Move indoc to dev-dependencies so that crates depending on us don't need it.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ time = "0.1"
 parking_lot = "0.7"
 log = "0.4"
 pretty_env_logger = "0.2"
-indoc = "0.2"
 hyper = "0.12"
 hyper-alpn = "0.1"
 
@@ -40,3 +39,4 @@ features = ["serde"]
 
 [dev-dependencies]
 argparse = "0.2"
+indoc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 
-#[allow(unused_imports)]
+#[cfg(test)]
 #[macro_use]
 extern crate indoc;
 


### PR DESCRIPTION
It's only used for tests anyway. Kept pre-2018 `extern crate` to keep this PR focused on the dev-dependency move.

Note: needs #35 merged first for `cargo test` to work.