### PR TITLE
Move pretty_env_logger to dev-dependencies, it's not useful to crates depending on us.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,10 @@ base64 = "0.9"
 time = "0.1"
 parking_lot = "0.7"
 log = "0.4"
-pretty_env_logger = "0.2"
 indoc = "0.2"
 hyper = "0.12"
 hyper-alpn = "0.1"
 
-[dependencies.chrono]
-version = "0.4"
-features = ["serde"]
-
 [dev-dependencies]
 argparse = "0.2"
+pretty_env_logger = "0.2"


### PR DESCRIPTION
Also removes chrono configuration, which was only used by `pretty_env_logger`. Everything still runs fine.

Note: needs #35 before `cargo test` can run.