### PR TITLE
Make apns_priority in NotificationOptions an Option<Priority>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,10 @@
 //! ```no_run
 //! #[macro_use] extern crate serde_derive;
 //!
-//! use a2::{Client, Endpoint, SilentNotificationBuilder, NotificationBuilder};
+//! use a2::{
+//!     Client, Endpoint, SilentNotificationBuilder, NotificationBuilder, NotificationOptions, 
+//!     Priority,
+//! };
 //! use std::fs::File;
 //!
 //! #[derive(Serialize, Debug)]
@@ -80,7 +83,12 @@
 //!     };
 //!
 //!     let mut payload = SilentNotificationBuilder::new()
-//!         .build("device-token-from-the-user", Default::default());
+//!         .build("device-token-from-the-user",
+//!         NotificationOptions {
+//!             apns_priority: Some(Priority::Normal),
+//!             ..Default::default()
+//!         },
+//!     );
 //!     payload.add_custom_data("apns_gmbh", &tracking_data)?;
 //!
 //!     let mut file = File::open("/path/to/cert_db.p12")?;

--- a/src/request/notification/options.rs
+++ b/src/request/notification/options.rs
@@ -37,8 +37,8 @@ pub struct NotificationOptions<'a> {
     /// the notification or attempt to redeliver it.
     pub apns_expiration: Option<u64>,
 
-    /// The priority of the notification.
-    pub apns_priority: Priority,
+    /// The priority of the notification. If `None`, the APNs server sets the priority to High.
+    pub apns_priority: Option<Priority>,
 
     /// The topic of the remote notification, which is typically the bundle ID
     /// for your app. The certificate you create in your developer account must
@@ -67,7 +67,7 @@ impl<'a> Default for NotificationOptions<'a> {
         NotificationOptions {
             apns_id: None,
             apns_expiration: None,
-            apns_priority: Priority::Normal,
+            apns_priority: None,
             apns_topic: None,
             apns_collapse_id: None,
         }


### PR DESCRIPTION
Fixes #40. I've tested both Plain (using default options) and Silent (using `Priority::Normal`) in iOS 9 using a developer certificate.