### PR TITLE
Fix `TooManyProviderTokenUpdates` issue

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -113,7 +113,7 @@ impl Client {
         R: Read,
     {
         let connector = AlpnConnector::new();
-        let signature_ttl = Duration::from_secs(45);
+        let signature_ttl = Duration::from_secs(60 * 55);
         let signer = Signer::new(pkcs8_pem, key_id, team_id, signature_ttl)?;
 
         Ok(Self::new(connector, Some(signer), endpoint))


### PR DESCRIPTION
I've tweaked token signature TTL to 55 minutes to avoid triggering `TooManyProviderTokenUpdates` errors which I was reliably seeing after about a minute when sending push notifications periodically every 10 seconds as a test.

The Apple docs mention the token should be refreshed at least once every 60 minutes https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html

<img width="715" alt="image" src="https://user-images.githubusercontent.com/409333/81769953-32af5700-9522-11ea-81b9-be29416e0b5a.png">
