### PR TITLE
feat: add implementation to support safari web push

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ mod signer;
 
 pub use crate::request::notification::{
     CollapseId, LocalizedNotificationBuilder, NotificationBuilder, NotificationOptions, PlainNotificationBuilder,
-    Priority, SilentNotificationBuilder,
+    Priority, SilentNotificationBuilder, WebNotificationBuilder, WebPushAlert
 };
 
 pub use crate::response::{ErrorBody, ErrorReason, Response};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ mod signer;
 
 pub use crate::request::notification::{
     CollapseId, LocalizedNotificationBuilder, NotificationBuilder, NotificationOptions, PlainNotificationBuilder,
-    Priority, SilentNotificationBuilder, WebNotificationBuilder, WebPushAlert
+    Priority, SilentNotificationBuilder, WebNotificationBuilder, WebPushAlert,
 };
 
 pub use crate::response::{ErrorBody, ErrorReason, Response};

--- a/src/request/notification.rs
+++ b/src/request/notification.rs
@@ -4,11 +4,13 @@ mod localized;
 mod options;
 mod plain;
 mod silent;
+mod web;
 
 pub use self::localized::{LocalizedAlert, LocalizedNotificationBuilder};
 pub use self::options::{CollapseId, NotificationOptions, Priority};
 pub use self::plain::PlainNotificationBuilder;
 pub use self::silent::SilentNotificationBuilder;
+pub use self::web::{WebNotificationBuilder, WebPushAlert};
 
 use crate::request::payload::Payload;
 

--- a/src/request/notification/localized.rs
+++ b/src/request/notification/localized.rs
@@ -315,6 +315,7 @@ impl<'a> NotificationBuilder<'a> for LocalizedNotificationBuilder<'a> {
                 content_available: None,
                 category: self.category,
                 mutable_content: Some(self.mutable_content),
+                url_args: None,
             },
             device_token,
             options,

--- a/src/request/notification/plain.rs
+++ b/src/request/notification/plain.rs
@@ -120,6 +120,7 @@ impl<'a> NotificationBuilder<'a> for PlainNotificationBuilder<'a> {
                 content_available: None,
                 category: self.category,
                 mutable_content: None,
+                url_args: None,
             },
             device_token,
             options,

--- a/src/request/notification/silent.rs
+++ b/src/request/notification/silent.rs
@@ -66,6 +66,7 @@ impl<'a> NotificationBuilder<'a> for SilentNotificationBuilder {
                 content_available: Some(self.content_available),
                 category: None,
                 mutable_content: None,
+                url_args: None,
             },
             device_token,
             options,

--- a/src/request/notification/web.rs
+++ b/src/request/notification/web.rs
@@ -17,7 +17,7 @@ pub struct WebPushAlert<'a> {
 /// ```rust
 /// # use a2::request::notification::{NotificationBuilder, WebNotificationBuilder, WebPushAlert};
 /// # fn main() {
-/// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, vec!["arg1"]);
+/// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, &["arg1"]);
 /// builder.set_sound("prööt");
 /// let payload = builder.build("device_id", Default::default())
 ///    .to_json_string().unwrap();
@@ -26,7 +26,7 @@ pub struct WebPushAlert<'a> {
 pub struct WebNotificationBuilder<'a> {
     alert: WebPushAlert<'a>,
     sound: Option<&'a str>,
-    url_args: &'a Vec<&'a str>,
+    url_args: &'a [&'a str],
 }
 
 impl<'a> WebNotificationBuilder<'a> {
@@ -35,16 +35,16 @@ impl<'a> WebNotificationBuilder<'a> {
     /// ```rust
     /// # use a2::request::notification::{WebNotificationBuilder, NotificationBuilder, WebPushAlert};
     /// # fn main() {
-    /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, vec!["arg1"]);
-    ///     .build("token", Default::default());
+    /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, &["arg1"]);
+    /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":\{"title": "Hello"\,\"body\":\"World\",\"action\":\"View\",\"url-args\":\[\"arg1\"\]}}}",
+    ///     "{\"aps\":{\"alert\":{\"action\":\"View\",\"body\":\"World\",\"title\":\"Hello\"},\"url-args\":[\"arg1\"]}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
     /// ```
-    pub fn new(alert: WebPushAlert<'a>, url_args: &'a Vec<&'a str>) -> WebNotificationBuilder<'a> {
+    pub fn new(alert: WebPushAlert<'a>, url_args: &'a [&'a str]) -> WebNotificationBuilder<'a> {
         WebNotificationBuilder {
             alert,
             sound: None,
@@ -55,14 +55,14 @@ impl<'a> WebNotificationBuilder<'a> {
     /// File name of the custom sound to play when receiving the notification.
     ///
     /// ```rust
-    /// # use a2::request::notification::{WebNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::notification::{WebNotificationBuilder, NotificationBuilder, WebPushAlert};
     /// # fn main() {
-    /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, vec!["arg1"]);
+    /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, &["arg1"]);
     /// builder.set_sound("meow");
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":\{"title": "Hello"\,\"body\":\"World\",\"action\":\"View\",\"url-args\":\[\"arg1\"\,\"sound\":\"meow\"]}}}",
+    ///     "{\"aps\":{\"alert\":{\"action\":\"View\",\"body\":\"World\",\"title\":\"Hello\"},\"sound\":\"meow\",\"url-args\":[\"arg1\"]}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }

--- a/src/request/notification/web.rs
+++ b/src/request/notification/web.rs
@@ -1,0 +1,122 @@
+use crate::request::notification::{NotificationBuilder, NotificationOptions};
+use crate::request::payload::{APSAlert, Payload, APS};
+use std::collections::BTreeMap;
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct WebPushAlert<'a> {
+    pub title: &'a str,
+    pub body: &'a str,
+    pub action: &'a str,
+}
+
+/// A builder to create a simple APNs notification payload.
+///
+/// # Example
+///
+/// ```rust
+/// # use a2::request::notification::{NotificationBuilder, WebNotificationBuilder, WebPushAlert};
+/// # fn main() {
+/// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, vec!["arg1"]);
+/// builder.set_sound("prööt");
+/// let payload = builder.build("device_id", Default::default())
+///    .to_json_string().unwrap();
+/// # }
+/// ```
+pub struct WebNotificationBuilder<'a> {
+    alert: WebPushAlert<'a>,
+    sound: Option<&'a str>,
+    url_args: &'a Vec<&'a str>
+}
+
+impl<'a> WebNotificationBuilder<'a> {
+    /// Creates a new builder with the minimum amount of content.
+    ///
+    /// ```rust
+    /// # use a2::request::notification::{WebNotificationBuilder, NotificationBuilder, WebPushAlert};
+    /// # fn main() {
+    /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, vec!["arg1"]);
+    ///     .build("token", Default::default());
+    ///
+    /// assert_eq!(
+    ///     "{\"aps\":{\"alert\":\{"title": "Hello"\,\"body\":\"World\",\"action\":\"View\",\"url-args\":\[\"arg1\"\]}}}",
+    ///     &payload.to_json_string().unwrap()
+    /// );
+    /// # }
+    /// ```
+    pub fn new(alert: WebPushAlert<'a>, url_args: &'a Vec<&'a str>) -> WebNotificationBuilder<'a> {
+        WebNotificationBuilder {
+            alert,
+            sound: None,
+            url_args: url_args,
+        }
+    }
+
+    /// File name of the custom sound to play when receiving the notification.
+    ///
+    /// ```rust
+    /// # use a2::request::notification::{WebNotificationBuilder, NotificationBuilder};
+    /// # fn main() {
+    /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, vec!["arg1"]);
+    /// builder.set_sound("meow");
+    /// let payload = builder.build("token", Default::default());
+    ///
+    /// assert_eq!(
+    ///     "{\"aps\":{\"alert\":\{"title": "Hello"\,\"body\":\"World\",\"action\":\"View\",\"url-args\":\[\"arg1\"\,\"sound\":\"meow\"]}}}",
+    ///     &payload.to_json_string().unwrap()
+    /// );
+    /// # }
+    /// ```
+    pub fn set_sound(&mut self, sound: &'a str) -> &mut Self {
+        self.sound = Some(sound);
+        self
+    }
+
+}
+
+impl<'a> NotificationBuilder<'a> for WebNotificationBuilder<'a> {
+    fn build(self, device_token: &'a str, options: NotificationOptions<'a>) -> Payload<'a> {
+        Payload {
+            aps: APS {
+                alert: Some(APSAlert::WebPush(self.alert)),
+                badge: None,
+                sound: self.sound,
+                content_available: None,
+                category: None,
+                mutable_content: None,
+                url_args: Some(self.url_args),
+            },
+            device_token,
+            options,
+            data: BTreeMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_webpush_notification() {
+        let payload = WebNotificationBuilder::new(WebPushAlert{action: "View", title: "Hello", body: "world"}, &vec!["arg1"])
+            .build("device-token", Default::default())
+            .to_json_string()
+            .unwrap();
+
+        let expected_payload = json!({
+            "aps": {
+                "alert": {
+                    "body": "world",
+                    "action": "View",
+                    "title": "Hello"
+                },
+                "url-args": "[\"arg1\"]"
+            }
+        })
+        .to_string();
+
+        assert_eq!(expected_payload, payload);
+    }
+
+}

--- a/src/request/notification/web.rs
+++ b/src/request/notification/web.rs
@@ -26,7 +26,7 @@ pub struct WebPushAlert<'a> {
 pub struct WebNotificationBuilder<'a> {
     alert: WebPushAlert<'a>,
     sound: Option<&'a str>,
-    url_args: &'a Vec<&'a str>
+    url_args: &'a Vec<&'a str>,
 }
 
 impl<'a> WebNotificationBuilder<'a> {
@@ -71,7 +71,6 @@ impl<'a> WebNotificationBuilder<'a> {
         self.sound = Some(sound);
         self
     }
-
 }
 
 impl<'a> NotificationBuilder<'a> for WebNotificationBuilder<'a> {
@@ -99,10 +98,17 @@ mod tests {
 
     #[test]
     fn test_webpush_notification() {
-        let payload = WebNotificationBuilder::new(WebPushAlert{action: "View", title: "Hello", body: "world"}, &vec!["arg1"])
-            .build("device-token", Default::default())
-            .to_json_string()
-            .unwrap();
+        let payload = WebNotificationBuilder::new(
+            WebPushAlert {
+                action: "View",
+                title: "Hello",
+                body: "world",
+            },
+            &vec!["arg1"],
+        )
+        .build("device-token", Default::default())
+        .to_json_string()
+        .unwrap();
 
         let expected_payload = json!({
             "aps": {
@@ -111,12 +117,11 @@ mod tests {
                     "action": "View",
                     "title": "Hello"
                 },
-                "url-args": "[\"arg1\"]"
+                "url-args": ["arg1"]
             }
         })
         .to_string();
 
         assert_eq!(expected_payload, payload);
     }
-
 }

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -119,7 +119,7 @@ pub struct APS<'a> {
     pub mutable_content: Option<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url_args: Option<&'a Vec<&'a str>>,
+    pub url_args: Option<&'a [&'a str]>,
 }
 
 /// Different notification content types.

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -1,7 +1,7 @@
 //! Payload with `aps` and custom data
 
 use crate::error::Error;
-use crate::request::notification::{LocalizedAlert, NotificationOptions};
+use crate::request::notification::{LocalizedAlert, NotificationOptions, WebPushAlert};
 use erased_serde::Serialize;
 use serde_json::{self, Value};
 use std::collections::BTreeMap;
@@ -117,6 +117,10 @@ pub struct APS<'a> {
     /// displaying it to the user.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mutable_content: Option<u8>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url_args: Option<&'a Vec<&'a str>>,
+
 }
 
 /// Different notification content types.
@@ -127,4 +131,6 @@ pub enum APSAlert<'a> {
     Plain(&'a str),
     /// A rich localized notification.
     Localized(LocalizedAlert<'a>),
+    /// Safari web push notification
+    WebPush(WebPushAlert<'a>),
 }

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -120,7 +120,6 @@ pub struct APS<'a> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url_args: Option<&'a Vec<&'a str>>,
-
 }
 
 /// Different notification content types.


### PR DESCRIPTION
* Added support for safari web push.

https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html

```json
{
 "aps": {
    "alert": {
        "title": "Flight A998 Now Boarding",
        "body": "Boarding has begun for Flight A998.",
        "action": "View"
    },
 "url-args": ["arg1", "arg2"]
 }
}


```