### PR TITLE
feat: add support for thread-id

### DIFF
--- a/src/request/notification/default.rs
+++ b/src/request/notification/default.rs
@@ -95,6 +95,7 @@ pub struct DefaultAlert<'a> {
 ///     .set_badge(420)
 ///     .set_category("cat1")
 ///     .set_sound("prööt")
+///     .set_thread_id("my-thread")
 ///     .set_critical(false, None)
 ///     .set_mutable_content()
 ///     .set_action_loc_key("PLAY")
@@ -113,6 +114,7 @@ pub struct DefaultNotificationBuilder<'a> {
     alert: DefaultAlert<'a>,
     badge: Option<u32>,
     sound: DefaultSound<'a>,
+    thread_id: Option<&'a str>,
     category: Option<&'a str>,
     mutable_content: u8,
     content_available: Option<u8>,
@@ -156,6 +158,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
                 name: None,
                 volume: None,
             },
+            thread_id: None,
             category: None,
             mutable_content: 0,
             content_available: None,
@@ -299,6 +302,28 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// ```
     pub fn set_sound(mut self, sound: &'a str) -> Self {
         self.sound.name = Some(sound);
+        self
+    }
+
+    /// An application-specific name that allows notifications to be grouped together.
+    ///
+    /// ```rust
+    /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
+    /// # fn main() {
+    /// let mut builder = DefaultNotificationBuilder::new()
+    ///     .set_title("a title")
+    ///     .set_thread_id("my-thread");
+    /// let payload = builder.build("token", Default::default());
+    ///
+    /// assert_eq!(
+    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\"},\"thread-id\":\"my-thread\",\"mutable-content\":0}}",
+    ///     &payload.to_json_string().unwrap()
+    /// );
+    /// # }
+    /// ```
+    pub fn set_thread_id(mut self, thread_id: &'a str) -> Self {
+        self.thread_id = Some(thread_id);
         self
     }
 
@@ -532,6 +557,7 @@ impl<'a> NotificationBuilder<'a> for DefaultNotificationBuilder<'a> {
                 } else {
                     self.sound.name.map(APSSound::Sound)
                 },
+                thread_id: self.thread_id,
                 content_available: self.content_available,
                 category: self.category,
                 mutable_content: Some(self.mutable_content),

--- a/src/request/notification/web.rs
+++ b/src/request/notification/web.rs
@@ -83,6 +83,7 @@ impl<'a> NotificationBuilder<'a> for WebNotificationBuilder<'a> {
                 alert: Some(APSAlert::WebPush(self.alert)),
                 badge: None,
                 sound: self.sound.map(APSSound::Sound),
+                thread_id: None,
                 content_available: None,
                 category: None,
                 mutable_content: None,

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -173,6 +173,10 @@ pub struct APS<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sound: Option<APSSound<'a>>,
 
+    /// An app-specific identifier for grouping related notifications.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<&'a str>,
+
     /// Set to one for silent notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content_available: Option<u8>,


### PR DESCRIPTION
# Description

This pull requests introduces support for the `thread-id` field (see https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification).

It is backward compatible (AFAIK), and the doctests are included.