### PR TITLE
Add TLS 1.2 support via configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "a2"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "argparse",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a2"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
   "Harry Bairstow <harry@walletconnect.com>",
   "Julius de Bruijn <julius@nauk.io>",


### PR DESCRIPTION
# Description

N.B.: This PR is combined is meant to be reviewed alongside https://github.com/WalletConnect/a2/pull/91

This PR adds a TLS 1.2 override to `ClientConfig`. This is useful in cases where we want to use a signing scheme that is not supported by TLS 1.3.

Resolves # (issue) N/A

## How Has This Been Tested?

I've pulled my fork into our own internal codebase and tested this by signing using RSA `PKCS1v15` signing scheme, something that is [*NOT* supported by TLS 1.3 for client auth](https://www.ietf.org/archive/id/draft-ietf-tls-rfc8446bis-03.html#section-4.4.3-16:~:text=.%20The%20SHA%2D1%20algorithm%20MUST%20NOT%20be%20used%20in%20any%20signatures%20of%20CertificateVerify%20messages). Got push notifications successfully sending to my device!

`*` Writing a unit test is fairly difficult here, so please let me know if you'd like me to add to `examples/certificate_client.rs`

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update