### PR TITLE
Choose client cert dynamically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "a2"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "argparse",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "a2"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "argparse",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a2"
-version = "0.10.1"
+version = "0.10.2"
 authors = [
   "Harry Bairstow <harry@walletconnect.com>",
   "Julius de Bruijn <julius@nauk.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a2"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
   "Harry Bairstow <harry@walletconnect.com>",
   "Julius de Bruijn <julius@nauk.io>",

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,7 +16,7 @@ use hyper_rustls::{ConfigBuilderExt, HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client as HttpClient;
 use hyper_util::rt::TokioExecutor;
-use rustls::client::ResolvesClientCert;
+pub use rustls::client::ResolvesClientCert;
 use std::convert::Infallible;
 use std::io::Read;
 use std::sync::Arc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,6 @@ pub use crate::request::notification::{
 
 pub use crate::response::{ErrorBody, ErrorReason, Response};
 
-pub use crate::client::{Client, ClientConfig, Endpoint};
+pub use crate::client::{Client, ClientConfig, Endpoint, ResolvesClientCert};
 
 pub use crate::error::Error;


### PR DESCRIPTION
# Description

N.B.: This PR is based on top of https://github.com/WalletConnect/a2/pull/90

This PR exists a way to use [rustls's `ConfigBuilder::with_client_cert_resolver`](https://docs.rs/rustls/latest/rustls/struct.ConfigBuilder.html#method.with_client_cert_resolver) for client auth. This allows us to do two things:

1) Dynamically choose a client cert + private key
2) Issue signatures without direct access to private key pem

Reason 2 is personally why I implemented this. We generate our keypairs inside AWS KMS which does not allow for retrieving the private key -- we can only call into AWS KMS to perform a `sign()`


Resolves # (issue) N/A

## How Has This Been Tested?

I've pulled my fork into our own internal codebase and tested this by integrating it into our own push notification flow. Got push notifications successfully sending to my device! 

`*` Writing a unit test is fairly difficult here, so please let me know if you'd like me to add to `examples/certificate_client.rs`

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update