### PR TITLE
Support custom endpoints

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -16,6 +16,7 @@ use hyper_rustls::{ConfigBuilderExt, HttpsConnector, HttpsConnectorBuilder};
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client as HttpClient;
 use hyper_util::rt::TokioExecutor;
+use std::borrow::Cow;
 use std::convert::Infallible;
 use std::io::Read;
 use std::time::Duration;
@@ -28,6 +29,8 @@ type HyperConnector = HttpsConnector<HttpConnector>;
 /// The APNs service endpoint to connect.
 #[derive(Debug, Clone)]
 pub enum Endpoint {
+    /// Custom endpoint.
+    Custom(Cow<'static, str>),
     /// The production environment (api.push.apple.com)
     Production,
     /// The development/test environment (api.development.push.apple.com)
@@ -37,11 +40,12 @@ pub enum Endpoint {
 impl fmt::Display for Endpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let host = match self {
+            Endpoint::Custom(host) => host.as_ref(),
             Endpoint::Production => "api.push.apple.com",
             Endpoint::Sandbox => "api.development.push.apple.com",
         };
 
-        write!(f, "{}", host)
+        write!(f, "{host}")
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -34,7 +34,7 @@ type HyperConnector = HttpsConnector<HttpConnector>;
 pub enum Endpoint {
     /// Custom endpoint [`Uri`].
     ///
-    /// [`Uri::path`] should not contain trailing `/`.
+    /// [`Uri::path`] should contain trailing `/`.
     Custom(Uri),
 
     /// The production environment (`https://api.push.apple.com`).
@@ -49,8 +49,8 @@ impl fmt::Display for Endpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Endpoint::Custom(uri) => write!(f, "{uri}"),
-            Endpoint::Production => write!(f, "https://api.push.apple.com"),
-            Endpoint::Sandbox => write!(f, "https://api.development.push.apple.com"),
+            Endpoint::Production => write!(f, "https://api.push.apple.com/"),
+            Endpoint::Sandbox => write!(f, "https://api.development.push.apple.com/"),
         }
     }
 }
@@ -267,10 +267,10 @@ impl Client {
     }
 
     fn build_request<T: PayloadLike>(&self, payload: T) -> Result<hyper::Request<BoxBody<Bytes, Infallible>>, Error> {
-        let path = format!("{}/3/device/{}", self.options.endpoint, payload.get_device_token());
+        let uri = format!("{}3/device/{}", self.options.endpoint, payload.get_device_token());
 
         let mut builder = hyper::Request::builder()
-            .uri(&path)
+            .uri(&uri)
             .method("POST")
             .header(CONTENT_TYPE, "application/json");
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -29,19 +29,19 @@ type HyperConnector = HttpsConnector<HttpConnector>;
 /// The APNs service endpoint to send requests to.
 ///
 /// Being appended with device token the notification
-/// is sent to in `[endpoint]/[device_token]` format.
+/// is sent to in a `[endpoint]/[device_token]` format.
 #[derive(Debug, Clone)]
 pub enum Endpoint {
     /// Custom endpoint [`Uri`].
     ///
-    /// [`Uri::path`] should not contains trailing `/`.
+    /// [`Uri::path`] should not contain trailing `/`.
     Custom(Uri),
 
-    /// The production environment (`https://api.push.apple.com/3/device`).
+    /// The production environment (`https://api.push.apple.com`).
     Production,
 
     /// The development/test environment
-    /// (`https://api.development.push.apple.com/3/device`).
+    /// (`https://api.development.push.apple.com`).
     Sandbox,
 }
 
@@ -49,8 +49,8 @@ impl fmt::Display for Endpoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Endpoint::Custom(uri) => write!(f, "{uri}"),
-            Endpoint::Production => write!(f, "https://api.push.apple.com/3/device"),
-            Endpoint::Sandbox => write!(f, "https://api.development.push.apple.com/3/device"),
+            Endpoint::Production => write!(f, "https://api.push.apple.com"),
+            Endpoint::Sandbox => write!(f, "https://api.development.push.apple.com"),
         }
     }
 }
@@ -267,7 +267,7 @@ impl Client {
     }
 
     fn build_request<T: PayloadLike>(&self, payload: T) -> Result<hyper::Request<BoxBody<Bytes, Infallible>>, Error> {
-        let path = format!("{}/{}", self.options.endpoint, payload.get_device_token());
+        let path = format!("{}/3/device/{}", self.options.endpoint, payload.get_device_token());
 
         let mut builder = hyper::Request::builder()
             .uri(&path)


### PR DESCRIPTION
# Description

Provides support for specifying custom `a2::Endpoint`. Custom endpoints are necessary for testing purposes (mock APNs services and assert the requests).

## How Has This Been Tested?

1. Bind simple http server;
2. Specify server url as `a2::Endpoint::Custom`;
3. Send something;
4. See the request in http server logs.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update