### PR TITLE
Add more `ErrorReason`s

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -102,6 +102,9 @@ pub enum ErrorReason {
     /// The provider token is not valid or the token signature could not be verified.
     InvalidProviderToken,
 
+    /// The `apns-push-type` attribute is set to an incorrect value.
+    InvalidPushType,
+
     /// No provider certificate was used to connect to APNs and Authorization
     /// header was missing or no provider token was specified.
     MissingProviderToken,
@@ -174,6 +177,8 @@ impl fmt::Display for ErrorReason {
                 "The specified action is not allowed.",
             ErrorReason::InvalidProviderToken =>
                 "The provider token is not valid or the token signature could not be verified.",
+            ErrorReason::InvalidPushType =>
+                "The `apns-push-type` attribute is set to an incorrect value.",
             ErrorReason::MissingProviderToken =>
                 "No provider certificate was used to connect to APNs and Authorization header was missing or no provider token was specified.",
             ErrorReason::BadPath =>

--- a/src/response.rs
+++ b/src/response.rs
@@ -96,6 +96,9 @@ pub enum ErrorReason {
     /// The provider token is stale and a new token should be generated.
     ExpiredProviderToken,
 
+    /// The device token has expired.
+    ExpiredToken,
+
     /// The specified action is not allowed.
     Forbidden,
 
@@ -173,6 +176,8 @@ impl fmt::Display for ErrorReason {
                 "The client certificate was for the wrong environment.",
             ErrorReason::ExpiredProviderToken =>
                 "The provider token is stale and a new token should be generated.",
+            ErrorReason::ExpiredToken =>
+                "The device token has expired.",
             ErrorReason::Forbidden =>
                 "The specified action is not allowed.",
             ErrorReason::InvalidProviderToken =>


### PR DESCRIPTION
# Description

- `InvalidPushType` error reason can occur if send notification type to the device not supported it (For example if send `background` notification to VoIP device token);
- `ExpiredToken` error reason can occur if token was not used for a long time (or if the target application was uninstalled from the device?).

## How Has This Been Tested?

"apns-push-type": "background" was sent to VoIP device to ensure `InvalidPushType` throws (works only on `Endpoint::Sandbox`).

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update