### PR TITLE
feat: switch from `&str` params to `String`

### DIFF
--- a/examples/certificate_client.rs
+++ b/examples/certificate_client.rs
@@ -57,17 +57,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let client = new_client()?;
 
     let options = NotificationOptions {
-        apns_topic: topic.as_deref(),
+        apns_topic: topic,
         ..Default::default()
     };
 
     // Notification payload
     let builder = DefaultNotificationBuilder::new()
-        .set_body(message.as_ref())
-        .set_sound("default")
+        .set_body(message)
+        .set_sound("default".to_string())
         .set_badge(1u32);
 
-    let payload = builder.build(device_token.as_ref(), options);
+    let payload = builder.build(device_token, options);
     let response = client.send(payload).await?;
 
     println!("Sent: {:?}", response);

--- a/examples/token_client.rs
+++ b/examples/token_client.rs
@@ -55,17 +55,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let client = Client::token(&mut private_key, key_id, team_id, client_config).unwrap();
 
     let options = NotificationOptions {
-        apns_topic: topic.as_deref(),
+        apns_topic: topic,
         ..Default::default()
     };
 
     // Notification payload
     let builder = DefaultNotificationBuilder::new()
-        .set_body(message.as_ref())
-        .set_sound("default")
+        .set_body(message)
+        .set_sound("default".to_string())
         .set_badge(1u32);
 
-    let payload = builder.build(device_token.as_ref(), options);
+    let payload = builder.build(device_token, options);
     let response = client.send(payload).await?;
 
     println!("Sent: {:?}", response);

--- a/src/client.rs
+++ b/src/client.rs
@@ -272,7 +272,7 @@ impl Client {
         if let Some(ref apns_priority) = options.apns_priority {
             builder = builder.header("apns-priority", apns_priority.to_string().as_bytes());
         }
-        if let Some(apns_id) = options.apns_id {
+        if let Some(apns_id) = options.apns_id.clone() {
             builder = builder.header("apns-id", apns_id.as_bytes());
         }
         if let Some(apns_push_type) = options.apns_push_type.as_ref() {
@@ -284,7 +284,7 @@ impl Client {
         if let Some(ref apns_collapse_id) = options.apns_collapse_id {
             builder = builder.header("apns-collapse-id", apns_collapse_id.value.as_bytes());
         }
-        if let Some(apns_topic) = options.apns_topic {
+        if let Some(apns_topic) = options.apns_topic.clone() {
             builder = builder.header("apns-topic", apns_topic.as_bytes());
         }
         if let Some(ref signer) = self.options.signer {
@@ -351,7 +351,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     #[test]
     fn test_production_request_uri() {
         let builder = DefaultNotificationBuilder::new();
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
         let client = Client::builder().build();
         let request = client.build_request(payload).unwrap();
         let uri = format!("{}", request.uri());
@@ -362,7 +362,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     #[test]
     fn test_sandbox_request_uri() {
         let builder = DefaultNotificationBuilder::new();
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
         let client = Client::builder()
             .config(ClientConfig {
                 endpoint: Endpoint::Sandbox,
@@ -378,7 +378,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     #[test]
     fn test_request_method() {
         let builder = DefaultNotificationBuilder::new();
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
         let client = Client::builder().build();
         let request = client.build_request(payload).unwrap();
 
@@ -388,7 +388,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     #[test]
     fn test_request_invalid() {
         let builder = DefaultNotificationBuilder::new();
-        let payload = builder.build("\r\n", Default::default());
+        let payload = builder.build("\r\n".to_string(), Default::default());
         let client = Client::builder().build();
         let request = client.build_request(payload);
 
@@ -398,7 +398,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     #[test]
     fn test_request_content_type() {
         let builder = DefaultNotificationBuilder::new();
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
         let client = Client::builder().build();
         let request = client.build_request(payload).unwrap();
 
@@ -408,7 +408,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     #[test]
     fn test_request_content_length() {
         let builder = DefaultNotificationBuilder::new();
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
         let client = Client::builder().build();
         let request = client.build_request(payload.clone()).unwrap();
         let payload_json = payload.to_json_string().unwrap();
@@ -420,7 +420,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     #[test]
     fn test_request_authorization_with_no_signer() {
         let builder = DefaultNotificationBuilder::new();
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
         let client = Client::builder().build();
         let request = client.build_request(payload).unwrap();
 
@@ -438,7 +438,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
         .unwrap();
 
         let builder = DefaultNotificationBuilder::new();
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
         let client = Client::builder().signer(signer).build();
         let request = client.build_request(payload).unwrap();
 
@@ -452,7 +452,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
             apns_push_type: Some(PushType::Background),
             ..Default::default()
         };
-        let payload = builder.build("a_test_id", options);
+        let payload = builder.build("a_test_id".to_string(), options);
         let client = Client::builder().build();
         let request = client.build_request(payload).unwrap();
         let apns_push_type = request.headers().get("apns-push-type").unwrap();
@@ -463,7 +463,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     #[test]
     fn test_request_with_default_priority() {
         let builder = DefaultNotificationBuilder::new();
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
         let client = Client::builder().build();
         let request = client.build_request(payload).unwrap();
         let apns_priority = request.headers().get("apns-priority");
@@ -476,7 +476,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
         let builder = DefaultNotificationBuilder::new();
 
         let payload = builder.build(
-            "a_test_id",
+            "a_test_id".to_string(),
             NotificationOptions {
                 apns_priority: Some(Priority::Normal),
                 ..Default::default()
@@ -495,7 +495,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
         let builder = DefaultNotificationBuilder::new();
 
         let payload = builder.build(
-            "a_test_id",
+            "a_test_id".to_string(),
             NotificationOptions {
                 apns_priority: Some(Priority::High),
                 ..Default::default()
@@ -513,7 +513,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     fn test_request_with_default_apns_id() {
         let builder = DefaultNotificationBuilder::new();
 
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
 
         let client = Client::builder().build();
         let request = client.build_request(payload).unwrap();
@@ -527,9 +527,9 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
         let builder = DefaultNotificationBuilder::new();
 
         let payload = builder.build(
-            "a_test_id",
+            "a_test_id".to_string(),
             NotificationOptions {
-                apns_id: Some("a-test-apns-id"),
+                apns_id: Some("a-test-apns-id".to_string()),
                 ..Default::default()
             },
         );
@@ -545,7 +545,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     fn test_request_with_default_apns_expiration() {
         let builder = DefaultNotificationBuilder::new();
 
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
 
         let client = Client::builder().build();
         let request = client.build_request(payload).unwrap();
@@ -559,7 +559,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
         let builder = DefaultNotificationBuilder::new();
 
         let payload = builder.build(
-            "a_test_id",
+            "a_test_id".to_string(),
             NotificationOptions {
                 apns_expiration: Some(420),
                 ..Default::default()
@@ -577,7 +577,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     fn test_request_with_default_apns_collapse_id() {
         let builder = DefaultNotificationBuilder::new();
 
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
 
         let client = Client::builder().build();
         let request = client.build_request(payload).unwrap();
@@ -591,9 +591,9 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
         let builder = DefaultNotificationBuilder::new();
 
         let payload = builder.build(
-            "a_test_id",
+            "a_test_id".to_string(),
             NotificationOptions {
-                apns_collapse_id: Some(CollapseId::new("a_collapse_id").unwrap()),
+                apns_collapse_id: Some(CollapseId::new("a_collapse_id".to_string()).unwrap()),
                 ..Default::default()
             },
         );
@@ -609,7 +609,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     fn test_request_with_default_apns_topic() {
         let builder = DefaultNotificationBuilder::new();
 
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
 
         let client = Client::builder().build();
         let request = client.build_request(payload).unwrap();
@@ -623,9 +623,9 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
         let builder = DefaultNotificationBuilder::new();
 
         let payload = builder.build(
-            "a_test_id",
+            "a_test_id".to_string(),
             NotificationOptions {
-                apns_topic: Some("a_topic"),
+                apns_topic: Some("a_topic".to_string()),
                 ..Default::default()
             },
         );
@@ -640,7 +640,7 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
     #[tokio::test]
     async fn test_request_body() {
         let builder = DefaultNotificationBuilder::new();
-        let payload = builder.build("a_test_id", Default::default());
+        let payload = builder.build("a_test_id".to_string(), Default::default());
         let client = Client::builder().build();
         let request = client.build_request(payload.clone()).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,12 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //! let mut builder = DefaultNotificationBuilder::new()
-//!     .set_body("Hi there")
+//!     .set_body("Hi there".to_owned())
 //!     .set_badge(420)
-//!     .set_category("cat1")
-//!     .set_sound("ping.flac");
+//!     .set_category("cat1".to_owned())
+//!     .set_sound("ping.flac".to_owned());
 //!
-//! let payload = builder.build("device-token-from-the-user", Default::default());
+//! let payload = builder.build("device-token-from-the-user".to_owned(), Default::default());
 //! let mut file = File::open("/path/to/private_key.p8")?;
 //!
 //! let client = Client::token(
@@ -71,26 +71,26 @@
 //!
 //! #[derive(Serialize, Debug)]
 //! struct CorporateData {
-//!     tracking_code: &'static str,
+//!     tracking_code: String,
 //!     is_paying_user: bool,
 //! }
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!     let tracking_data = CorporateData {
-//!         tracking_code: "999-212-UF-NSA",
+//!         tracking_code: "999-212-UF-NSA".to_owned(),
 //!         is_paying_user: false,
 //!     };
 //!
 //!     let mut payload = DefaultNotificationBuilder::new()
 //!         .set_content_available()
-//!         .build("device-token-from-the-user",
+//!         .build("device-token-from-the-user".to_owned(),
 //!         NotificationOptions {
 //!             apns_priority: Some(Priority::Normal),
 //!             ..Default::default()
 //!         },
 //!     );
-//!     payload.add_custom_data("apns_gmbh", &tracking_data)?;
+//!     payload.add_custom_data("apns_gmbh".to_owned(), &tracking_data)?;
 //!
 //!     let mut file = File::open("/path/to/cert_db.p12")?;
 //!

--- a/src/request/notification.rs
+++ b/src/request/notification.rs
@@ -9,7 +9,7 @@ pub use self::web::{WebNotificationBuilder, WebPushAlert};
 
 use crate::request::payload::Payload;
 
-pub trait NotificationBuilder<'a> {
+pub trait NotificationBuilder {
     /// Generates the request payload to be send with the `Client`.
-    fn build(self, device_token: &'a str, options: NotificationOptions<'a>) -> Payload<'a>;
+    fn build(self, device_token: String, options: NotificationOptions) -> Payload;
 }

--- a/src/request/notification.rs
+++ b/src/request/notification.rs
@@ -11,5 +11,5 @@ use crate::request::payload::Payload;
 
 pub trait NotificationBuilder {
     /// Generates the request payload to be send with the `Client`.
-    fn build(self, device_token: String, options: NotificationOptions) -> Payload;
+    fn build(self, device_token: impl Into<String>, options: NotificationOptions) -> Payload;
 }

--- a/src/request/notification/default.rs
+++ b/src/request/notification/default.rs
@@ -181,8 +181,8 @@ impl DefaultNotificationBuilder {
     /// );
     /// # }
     /// ```
-    pub fn set_title(mut self, title: String) -> Self {
-        self.alert.title = Some(title);
+    pub fn set_title(mut self, title: impl Into<String>) -> Self {
+        self.alert.title = Some(title.into());
         self.has_edited_alert = true;
         self
     }
@@ -232,8 +232,8 @@ impl DefaultNotificationBuilder {
     /// );
     /// # }
     /// ```
-    pub fn set_subtitle(mut self, subtitle: String) -> Self {
-        self.alert.subtitle = Some(subtitle);
+    pub fn set_subtitle(mut self, subtitle: impl Into<String>) -> Self {
+        self.alert.subtitle = Some(subtitle.into());
         self.has_edited_alert = true;
         self
     }
@@ -254,8 +254,8 @@ impl DefaultNotificationBuilder {
     /// );
     /// # }
     /// ```
-    pub fn set_body(mut self, body: String) -> Self {
-        self.alert.body = Some(body);
+    pub fn set_body(mut self, body: impl Into<String>) -> Self {
+        self.alert.body = Some(body.into());
         self
     }
 
@@ -297,8 +297,8 @@ impl DefaultNotificationBuilder {
     /// );
     /// # }
     /// ```
-    pub fn set_sound(mut self, sound: String) -> Self {
-        self.sound.name = Some(sound);
+    pub fn set_sound(mut self, sound: impl Into<String>) -> Self {
+        self.sound.name = Some(sound.into());
         self
     }
 
@@ -320,8 +320,8 @@ impl DefaultNotificationBuilder {
     /// );
     /// # }
     /// ```
-    pub fn set_category(mut self, category: String) -> Self {
-        self.category = Some(category);
+    pub fn set_category(mut self, category: impl Into<String>) -> Self {
+        self.category = Some(category.into());
         self
     }
 
@@ -342,8 +342,8 @@ impl DefaultNotificationBuilder {
     /// );
     /// # }
     /// ```
-    pub fn set_title_loc_key(mut self, key: String) -> Self {
-        self.alert.title_loc_key = Some(key);
+    pub fn set_title_loc_key(mut self, key: impl Into<String>) -> Self {
+        self.alert.title_loc_key = Some(key.into());
         self.has_edited_alert = true;
         self
     }
@@ -393,8 +393,8 @@ impl DefaultNotificationBuilder {
     /// );
     /// # }
     /// ```
-    pub fn set_action_loc_key(mut self, key: String) -> Self {
-        self.alert.action_loc_key = Some(key);
+    pub fn set_action_loc_key(mut self, key: impl Into<String>) -> Self {
+        self.alert.action_loc_key = Some(key.into());
         self.has_edited_alert = true;
         self
     }
@@ -416,8 +416,8 @@ impl DefaultNotificationBuilder {
     /// );
     /// # }
     /// ```
-    pub fn set_loc_key(mut self, key: String) -> Self {
-        self.alert.loc_key = Some(key);
+    pub fn set_loc_key(mut self, key: impl Into<String>) -> Self {
+        self.alert.loc_key = Some(key.into());
         self.has_edited_alert = true;
         self
     }
@@ -468,8 +468,8 @@ impl DefaultNotificationBuilder {
     /// );
     /// # }
     /// ```
-    pub fn set_launch_image(mut self, image: String) -> Self {
-        self.alert.launch_image = Some(image);
+    pub fn set_launch_image(mut self, image: impl Into<String>) -> Self {
+        self.alert.launch_image = Some(image.into());
         self.has_edited_alert = true;
         self
     }
@@ -520,7 +520,7 @@ impl DefaultNotificationBuilder {
 }
 
 impl NotificationBuilder for DefaultNotificationBuilder {
-    fn build(self, device_token: String, options: NotificationOptions) -> Payload {
+    fn build(self, device_token: impl Into<String>, options: NotificationOptions) -> Payload {
         Payload {
             aps: APS {
                 alert: match self.has_edited_alert {
@@ -538,7 +538,7 @@ impl NotificationBuilder for DefaultNotificationBuilder {
                 mutable_content: Some(self.mutable_content),
                 url_args: None,
             },
-            device_token,
+            device_token: device_token.into(),
             options,
             data: BTreeMap::new(),
         }

--- a/src/request/notification/default.rs
+++ b/src/request/notification/default.rs
@@ -1,7 +1,7 @@
 use crate::request::notification::{NotificationBuilder, NotificationOptions};
 use crate::request::payload::{APSAlert, APSSound, Payload, APS};
 
-use std::{borrow::Cow, collections::BTreeMap};
+use std::collections::BTreeMap;
 
 /// Represents a bool that serializes as a u8 0/1 for false/true respectively
 mod bool_as_u8 {
@@ -38,12 +38,12 @@ mod bool_as_u8 {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct DefaultSound<'a> {
+pub struct DefaultSound {
     #[serde(skip_serializing_if = "std::ops::Not::not", with = "bool_as_u8")]
     critical: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     volume: Option<f64>,
@@ -51,33 +51,33 @@ pub struct DefaultSound<'a> {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct DefaultAlert<'a> {
+pub struct DefaultAlert {
     #[serde(skip_serializing_if = "Option::is_none")]
-    title: Option<&'a str>,
+    title: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    subtitle: Option<&'a str>,
+    subtitle: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    body: Option<&'a str>,
+    body: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    title_loc_key: Option<&'a str>,
+    title_loc_key: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    title_loc_args: Option<Vec<Cow<'a, str>>>,
+    title_loc_args: Option<Vec<String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    action_loc_key: Option<&'a str>,
+    action_loc_key: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    loc_key: Option<&'a str>,
+    loc_key: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    loc_args: Option<Vec<Cow<'a, str>>>,
+    loc_args: Option<Vec<String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    launch_image: Option<&'a str>,
+    launch_image: Option<String>,
 }
 
 /// A builder to create an APNs payload.
@@ -89,37 +89,37 @@ pub struct DefaultAlert<'a> {
 /// # use a2::request::payload::PayloadLike;
 /// # fn main() {
 /// let mut builder = DefaultNotificationBuilder::new()
-///     .set_title("Hi there")
-///     .set_subtitle("From bob")
-///     .set_body("What's up?")
+///     .set_title("Hi there".to_owned())
+///     .set_subtitle("From bob".to_owned())
+///     .set_body("What's up?".to_owned())
 ///     .set_badge(420)
-///     .set_category("cat1")
-///     .set_sound("prööt")
+///     .set_category("cat1".to_owned())
+///     .set_sound("prööt".to_owned())
 ///     .set_critical(false, None)
 ///     .set_mutable_content()
-///     .set_action_loc_key("PLAY")
-///     .set_launch_image("foo.jpg")
-///     .set_loc_args(&["argh", "narf"])
-///     .set_title_loc_key("STOP")
-///     .set_title_loc_args(&["herp", "derp"])
-///     .set_loc_key("PAUSE")
-///     .set_loc_args(&["narf", "derp"]);
-/// let payload = builder.build("device_id", Default::default())
+///     .set_action_loc_key("PLAY".to_owned())
+///     .set_launch_image("foo.jpg".to_owned())
+///     .set_loc_args(vec!["argh".to_owned(), "narf".to_owned()])
+///     .set_title_loc_key("STOP".to_owned())
+///     .set_title_loc_args(vec!["herp".to_owned(), "derp".to_owned()])
+///     .set_loc_key("PAUSE".to_owned())
+///     .set_loc_args(vec!["narf".to_owned(), "derp".to_owned()]);
+/// let payload = builder.build("device_id".to_owned(), Default::default())
 ///   .to_json_string().unwrap();
 /// # }
 /// ```
 #[derive(Debug, Clone)]
-pub struct DefaultNotificationBuilder<'a> {
-    alert: DefaultAlert<'a>,
+pub struct DefaultNotificationBuilder {
+    alert: DefaultAlert,
     badge: Option<u32>,
-    sound: DefaultSound<'a>,
-    category: Option<&'a str>,
+    sound: DefaultSound,
+    category: Option<String>,
     mutable_content: u8,
     content_available: Option<u8>,
     has_edited_alert: bool,
 }
 
-impl<'a> DefaultNotificationBuilder<'a> {
+impl DefaultNotificationBuilder {
     /// Creates a new builder with the minimum amount of content.
     ///
     /// ```rust
@@ -127,9 +127,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let payload = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
-    ///     .set_body("a body")
-    ///     .build("token", Default::default());
+    ///     .set_title("a title".to_owned())
+    ///     .set_body("a body".to_owned())
+    ///     .build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"body\":\"a body\"},\"mutable-content\":0}}",
@@ -137,7 +137,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn new() -> DefaultNotificationBuilder<'a> {
+    pub fn new() -> DefaultNotificationBuilder {
         DefaultNotificationBuilder {
             alert: DefaultAlert {
                 title: None,
@@ -172,8 +172,8 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title");
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_title("a title".to_owned());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\"},\"mutable-content\":0}}",
@@ -181,7 +181,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_title(mut self, title: &'a str) -> Self {
+    pub fn set_title(mut self, title: String) -> Self {
         self.alert.title = Some(title);
         self.has_edited_alert = true;
         self
@@ -197,7 +197,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_critical(true, None);
-    /// let payload = builder.build("token", Default::default());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"sound\":{\"critical\":1},\"mutable-content\":0}}",
@@ -223,8 +223,8 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_subtitle("a subtitle");
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_subtitle("a subtitle".to_owned());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"subtitle\":\"a subtitle\"},\"mutable-content\":0}}",
@@ -232,7 +232,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_subtitle(mut self, subtitle: &'a str) -> Self {
+    pub fn set_subtitle(mut self, subtitle: String) -> Self {
         self.alert.subtitle = Some(subtitle);
         self.has_edited_alert = true;
         self
@@ -245,8 +245,8 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_body("a body");
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_body("a body".to_owned());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":\"a body\",\"mutable-content\":0}}",
@@ -254,7 +254,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_body(mut self, body: &'a str) -> Self {
+    pub fn set_body(mut self, body: String) -> Self {
         self.alert.body = Some(body);
         self
     }
@@ -267,7 +267,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_badge(4);
-    /// let payload = builder.build("token", Default::default());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"badge\":4,\"mutable-content\":0}}",
@@ -287,9 +287,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
-    ///     .set_sound("ping");
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_title("a title".to_owned())
+    ///     .set_sound("ping".to_owned());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\"},\"sound\":\"ping\",\"mutable-content\":0}}",
@@ -297,7 +297,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_sound(mut self, sound: &'a str) -> Self {
+    pub fn set_sound(mut self, sound: String) -> Self {
         self.sound.name = Some(sound);
         self
     }
@@ -310,9 +310,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
-    ///     .set_category("cat1");
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_title("a title".to_owned())
+    ///     .set_category("cat1".to_owned());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\"},\"category\":\"cat1\",\"mutable-content\":0}}",
@@ -320,7 +320,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_category(mut self, category: &'a str) -> Self {
+    pub fn set_category(mut self, category: String) -> Self {
         self.category = Some(category);
         self
     }
@@ -332,9 +332,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
-    ///     .set_title_loc_key("play");
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_title("a title".to_owned())
+    ///     .set_title_loc_key("play".to_owned());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"title-loc-key\":\"play\"},\"mutable-content\":0}}",
@@ -342,7 +342,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_title_loc_key(mut self, key: &'a str) -> Self {
+    pub fn set_title_loc_key(mut self, key: String) -> Self {
         self.alert.title_loc_key = Some(key);
         self.has_edited_alert = true;
         self
@@ -355,9 +355,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
-    ///     .set_title_loc_args(&["foo", "bar"]);
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_title("a title".to_owned())
+    ///     .set_title_loc_args(vec!["foo".to_owned(), "bar".to_owned()]);
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"title-loc-args\":[\"foo\",\"bar\"]},\"mutable-content\":0}}",
@@ -365,9 +365,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_title_loc_args<S>(mut self, args: &'a [S]) -> Self
+    pub fn set_title_loc_args<S>(mut self, args: Vec<S>) -> Self
     where
-        S: Into<Cow<'a, str>> + AsRef<str>,
+        S: Into<String> + AsRef<str>,
     {
         let converted = args.iter().map(|a| a.as_ref().into()).collect();
 
@@ -383,9 +383,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
-    ///     .set_action_loc_key("stop");
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_title("a title".to_owned())
+    ///     .set_action_loc_key("stop".to_owned());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"action-loc-key\":\"stop\"},\"mutable-content\":0}}",
@@ -393,7 +393,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_action_loc_key(mut self, key: &'a str) -> Self {
+    pub fn set_action_loc_key(mut self, key: String) -> Self {
         self.alert.action_loc_key = Some(key);
         self.has_edited_alert = true;
         self
@@ -406,9 +406,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
-    ///     .set_loc_key("lol");
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_title("a title".to_owned())
+    ///     .set_loc_key("lol".to_owned());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"loc-key\":\"lol\"},\"mutable-content\":0}}",
@@ -416,7 +416,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_loc_key(mut self, key: &'a str) -> Self {
+    pub fn set_loc_key(mut self, key: String) -> Self {
         self.alert.loc_key = Some(key);
         self.has_edited_alert = true;
         self
@@ -429,19 +429,20 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
-    ///     .set_loc_args(&["omg", "foo"]);
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_title("a title".to_owned())
+    ///     .set_loc_key("lol".to_owned())
+    ///     .set_loc_args(vec!["omg".to_owned(), "foo".to_owned()]);
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"loc-args\":[\"omg\",\"foo\"]},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"loc-key\":\"lol\",\"loc-args\":[\"omg\",\"foo\"]},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
     /// ```
-    pub fn set_loc_args<S>(mut self, args: &'a [S]) -> Self
+    pub fn set_loc_args<S>(mut self, args: Vec<S>) -> Self
     where
-        S: Into<Cow<'a, str>> + AsRef<str>,
+        S: Into<String> + AsRef<str>,
     {
         let converted = args.iter().map(|a| a.as_ref().into()).collect();
 
@@ -457,9 +458,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
-    ///     .set_launch_image("cat.png");
-    /// let payload = builder.build("token", Default::default());
+    ///     .set_title("a title".to_owned())
+    ///     .set_launch_image("cat.png".to_owned());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"launch-image\":\"cat.png\"},\"mutable-content\":0}}",
@@ -467,7 +468,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_launch_image(mut self, image: &'a str) -> Self {
+    pub fn set_launch_image(mut self, image: String) -> Self {
         self.alert.launch_image = Some(image);
         self.has_edited_alert = true;
         self
@@ -480,9 +481,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
+    ///     .set_title("a title".to_owned())
     ///     .set_mutable_content();
-    /// let payload = builder.build("token", Default::default());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\"},\"mutable-content\":1}}",
@@ -502,9 +503,9 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
-    ///     .set_title("a title")
+    ///     .set_title("a title".to_owned())
     ///     .set_content_available();
-    /// let payload = builder.build("token", Default::default());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"a title\"},\"content-available\":1,\"mutable-content\":0}}",
@@ -518,8 +519,8 @@ impl<'a> DefaultNotificationBuilder<'a> {
     }
 }
 
-impl<'a> NotificationBuilder<'a> for DefaultNotificationBuilder<'a> {
-    fn build(self, device_token: &'a str, options: NotificationOptions<'a>) -> Payload<'a> {
+impl NotificationBuilder for DefaultNotificationBuilder {
+    fn build(self, device_token: String, options: NotificationOptions) -> Payload {
         Payload {
             aps: APS {
                 alert: match self.has_edited_alert {
@@ -544,7 +545,7 @@ impl<'a> NotificationBuilder<'a> for DefaultNotificationBuilder<'a> {
     }
 }
 
-impl<'a> Default for DefaultNotificationBuilder<'a> {
+impl Default for DefaultNotificationBuilder {
     fn default() -> Self {
         Self::new()
     }
@@ -558,9 +559,9 @@ mod tests {
     #[test]
     fn test_default_notification_with_minimal_required_values() {
         let payload = DefaultNotificationBuilder::new()
-            .set_title("the title")
-            .set_body("the body")
-            .build("device-token", Default::default());
+            .set_title("the title".to_string())
+            .set_body("the body".to_string())
+            .build("device-token".to_string(), Default::default());
 
         let expected_payload = json!({
             "aps": {
@@ -578,22 +579,22 @@ mod tests {
     #[test]
     fn test_default_notification_with_full_data() {
         let builder = DefaultNotificationBuilder::new()
-            .set_title("the title")
-            .set_body("the body")
+            .set_title("the title".to_string())
+            .set_body("the body".to_string())
             .set_badge(420)
-            .set_category("cat1")
-            .set_sound("prööt")
+            .set_category("cat1".to_string())
+            .set_sound("prööt".to_string())
             .set_critical(true, Some(1.0))
             .set_mutable_content()
-            .set_action_loc_key("PLAY")
-            .set_launch_image("foo.jpg")
-            .set_loc_args(&["argh", "narf"])
-            .set_title_loc_key("STOP")
-            .set_title_loc_args(&["herp", "derp"])
-            .set_loc_key("PAUSE")
-            .set_loc_args(&["narf", "derp"]);
+            .set_action_loc_key("PLAY".to_string())
+            .set_launch_image("foo.jpg".to_string())
+            .set_loc_args(vec!["argh".to_string(), "narf".to_string()])
+            .set_title_loc_key("STOP".to_string())
+            .set_title_loc_args(vec!["herp".to_string(), "derp".to_string()])
+            .set_loc_key("PAUSE".to_string())
+            .set_loc_args(vec!["narf".to_string(), "derp".to_string()]);
 
-        let payload = builder.build("device-token", Default::default());
+        let payload = builder.build("device-token".to_string(), Default::default());
 
         let expected_payload = json!({
             "aps": {
@@ -625,30 +626,32 @@ mod tests {
     fn test_notification_with_custom_data_1() {
         #[derive(Serialize, Debug)]
         struct SubData {
-            nothing: &'static str,
+            nothing: String,
         }
 
         #[derive(Serialize, Debug)]
         struct TestData {
-            key_str: &'static str,
+            key_str: String,
             key_num: u32,
             key_bool: bool,
             key_struct: SubData,
         }
 
         let test_data = TestData {
-            key_str: "foo",
+            key_str: "foo".to_owned(),
             key_num: 42,
             key_bool: false,
-            key_struct: SubData { nothing: "here" },
+            key_struct: SubData {
+                nothing: "here".to_owned(),
+            },
         };
 
         let mut payload = DefaultNotificationBuilder::new()
-            .set_title("the title")
-            .set_body("the body")
-            .build("device-token", Default::default());
+            .set_title("the title".to_string())
+            .set_body("the body".to_string())
+            .build("device-token".to_string(), Default::default());
 
-        payload.add_custom_data("custom", &test_data).unwrap();
+        payload.add_custom_data("custom".to_string(), &test_data).unwrap();
 
         let expected_payload = json!({
             "custom": {
@@ -675,29 +678,31 @@ mod tests {
     fn test_notification_with_custom_data_2() {
         #[derive(Serialize, Debug)]
         struct SubData {
-            nothing: &'static str,
+            nothing: String,
         }
 
         #[derive(Serialize, Debug)]
         struct TestData {
-            key_str: &'static str,
+            key_str: String,
             key_num: u32,
             key_bool: bool,
             key_struct: SubData,
         }
 
         let test_data = TestData {
-            key_str: "foo",
+            key_str: "foo".to_owned(),
             key_num: 42,
             key_bool: false,
-            key_struct: SubData { nothing: "here" },
+            key_struct: SubData {
+                nothing: "here".to_owned(),
+            },
         };
 
         let mut payload = DefaultNotificationBuilder::new()
-            .set_body("kulli")
-            .build("device-token", Default::default());
+            .set_body("kulli".to_string())
+            .build("device-token".to_string(), Default::default());
 
-        payload.add_custom_data("custom", &test_data).unwrap();
+        payload.add_custom_data("custom".to_string(), &test_data).unwrap();
 
         let expected_payload = json!({
             "custom": {
@@ -721,7 +726,7 @@ mod tests {
     fn test_silent_notification_with_no_content() {
         let payload = DefaultNotificationBuilder::new()
             .set_content_available()
-            .build("device-token", Default::default());
+            .build("device-token".to_string(), Default::default());
 
         let expected_payload = json!({
             "aps": {
@@ -737,29 +742,31 @@ mod tests {
     fn test_silent_notification_with_custom_data() {
         #[derive(Serialize, Debug)]
         struct SubData {
-            nothing: &'static str,
+            nothing: String,
         }
 
         #[derive(Serialize, Debug)]
         struct TestData {
-            key_str: &'static str,
+            key_str: String,
             key_num: u32,
             key_bool: bool,
             key_struct: SubData,
         }
 
         let test_data = TestData {
-            key_str: "foo",
+            key_str: "foo".to_owned(),
             key_num: 42,
             key_bool: false,
-            key_struct: SubData { nothing: "here" },
+            key_struct: SubData {
+                nothing: "here".to_owned(),
+            },
         };
 
         let mut payload = DefaultNotificationBuilder::new()
             .set_content_available()
-            .build("device-token", Default::default());
+            .build("device-token".to_string(), Default::default());
 
-        payload.add_custom_data("custom", &test_data).unwrap();
+        payload.add_custom_data("custom".to_string(), &test_data).unwrap();
 
         let expected_payload = json!({
             "aps": {
@@ -787,9 +794,9 @@ mod tests {
 
         let mut payload = DefaultNotificationBuilder::new()
             .set_content_available()
-            .build("device-token", Default::default());
+            .build("device-token".to_string(), Default::default());
 
-        payload.add_custom_data("custom", &test_data).unwrap();
+        payload.add_custom_data("custom".to_string(), &test_data).unwrap();
 
         let expected_payload = json!({
             "aps": {

--- a/src/request/notification/options.rs
+++ b/src/request/notification/options.rs
@@ -2,13 +2,13 @@ use crate::error::Error;
 use std::fmt;
 
 #[derive(Debug, Clone)]
-pub struct CollapseId<'a> {
-    pub value: &'a str,
+pub struct CollapseId {
+    pub value: String,
 }
 
 /// A collapse-id container. Will not allow bigger id's than 64 bytes.
-impl<'a> CollapseId<'a> {
-    pub fn new(value: &'a str) -> Result<CollapseId<'a>, Error> {
+impl CollapseId {
+    pub fn new(value: String) -> Result<CollapseId, Error> {
         if value.len() > 64 {
             Err(Error::InvalidOptions(String::from(
                 "The collapse-id is too big. Maximum 64 bytes.",
@@ -69,11 +69,11 @@ impl fmt::Display for PushType {
 
 /// Headers to specify options to the notification.
 #[derive(Debug, Default, Clone)]
-pub struct NotificationOptions<'a> {
+pub struct NotificationOptions {
     /// A canonical UUID that identifies the notification. If there is an error
     /// sending the notification, APNs uses this value to identify the
     /// notification to your server.
-    pub apns_id: Option<&'a str>,
+    pub apns_id: Option<String>,
 
     /// The apns-push-type header field has the following valid values.
     ///
@@ -108,12 +108,12 @@ pub struct NotificationOptions<'a> {
     /// If you are using a provider token instead of a certificate, you must
     /// specify a value for this request header. The topic you provide should be
     /// provisioned for the your team named in your developer account.
-    pub apns_topic: Option<&'a str>,
+    pub apns_topic: Option<String>,
 
     /// Multiple notifications with the same collapse identifier are displayed to the
     /// user as a single notification. The value of this key must not exceed 64
     /// bytes.
-    pub apns_collapse_id: Option<CollapseId<'a>>,
+    pub apns_collapse_id: Option<CollapseId>,
 }
 
 /// The importance how fast to bring the notification for the user..
@@ -145,11 +145,10 @@ impl fmt::Display for Priority {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str;
 
     #[test]
     fn test_collapse_id_under_64_chars() {
-        let collapse_id = CollapseId::new("foo").unwrap();
+        let collapse_id = CollapseId::new("foo".to_string()).unwrap();
         assert_eq!("foo", collapse_id.value);
     }
 
@@ -158,7 +157,7 @@ mod tests {
         let mut long_string = Vec::with_capacity(65);
         long_string.extend_from_slice(&[65; 65]);
 
-        let collapse_id = CollapseId::new(str::from_utf8(&long_string).unwrap());
+        let collapse_id = CollapseId::new(String::from_utf8(long_string).unwrap());
         assert!(collapse_id.is_err());
     }
 }

--- a/src/request/notification/options.rs
+++ b/src/request/notification/options.rs
@@ -8,7 +8,8 @@ pub struct CollapseId {
 
 /// A collapse-id container. Will not allow bigger id's than 64 bytes.
 impl CollapseId {
-    pub fn new(value: String) -> Result<CollapseId, Error> {
+    pub fn new(value: impl Into<String>) -> Result<CollapseId, Error> {
+        let value = value.into();
         if value.len() > 64 {
             Err(Error::InvalidOptions(String::from(
                 "The collapse-id is too big. Maximum 64 bytes.",

--- a/src/request/notification/web.rs
+++ b/src/request/notification/web.rs
@@ -4,10 +4,10 @@ use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub struct WebPushAlert<'a> {
-    pub title: &'a str,
-    pub body: &'a str,
-    pub action: &'a str,
+pub struct WebPushAlert {
+    pub title: String,
+    pub body: String,
+    pub action: String,
 }
 
 /// A builder to create a simple APNs notification payload.
@@ -18,27 +18,27 @@ pub struct WebPushAlert<'a> {
 /// # use a2::request::notification::{NotificationBuilder, WebNotificationBuilder, WebPushAlert};
 /// # use a2::request::payload::PayloadLike;
 /// # fn main() {
-/// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, &["arg1"]);
-/// builder.set_sound("prööt");
-/// let payload = builder.build("device_id", Default::default())
+/// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello".to_owned(), body: "World".to_owned(), action: "View".to_owned()}, vec!["arg1".to_owned()]);
+/// builder.set_sound("prööt".to_owned());
+/// let payload = builder.build("device_id".to_owned(), Default::default())
 ///    .to_json_string().unwrap();
 /// # }
 /// ```
-pub struct WebNotificationBuilder<'a> {
-    alert: WebPushAlert<'a>,
-    sound: Option<&'a str>,
-    url_args: &'a [&'a str],
+pub struct WebNotificationBuilder {
+    alert: WebPushAlert,
+    sound: Option<String>,
+    url_args: Vec<String>,
 }
 
-impl<'a> WebNotificationBuilder<'a> {
+impl WebNotificationBuilder {
     /// Creates a new builder with the minimum amount of content.
     ///
     /// ```rust
     /// # use a2::request::notification::{WebNotificationBuilder, NotificationBuilder, WebPushAlert};
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
-    /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, &["arg1"]);
-    /// let payload = builder.build("token", Default::default());
+    /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello".to_owned(), body: "World".to_owned(), action: "View".to_owned()}, vec!["arg1".to_owned()]);
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"Hello\",\"body\":\"World\",\"action\":\"View\"},\"url-args\":[\"arg1\"]}}",
@@ -46,7 +46,7 @@ impl<'a> WebNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn new(alert: WebPushAlert<'a>, url_args: &'a [&'a str]) -> WebNotificationBuilder<'a> {
+    pub fn new(alert: WebPushAlert, url_args: Vec<String>) -> WebNotificationBuilder {
         WebNotificationBuilder {
             alert,
             sound: None,
@@ -60,9 +60,9 @@ impl<'a> WebNotificationBuilder<'a> {
     /// # use a2::request::notification::{WebNotificationBuilder, NotificationBuilder, WebPushAlert};
     /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
-    /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, &["arg1"]);
-    /// builder.set_sound("meow");
-    /// let payload = builder.build("token", Default::default());
+    /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello".to_owned(), body: "World".to_owned(), action: "View".to_owned()}, vec!["arg1".to_owned()]);
+    /// builder.set_sound("meow".to_owned());
+    /// let payload = builder.build("token".to_owned(), Default::default());
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"alert\":{\"title\":\"Hello\",\"body\":\"World\",\"action\":\"View\"},\"sound\":\"meow\",\"url-args\":[\"arg1\"]}}",
@@ -70,14 +70,14 @@ impl<'a> WebNotificationBuilder<'a> {
     /// );
     /// # }
     /// ```
-    pub fn set_sound(&mut self, sound: &'a str) -> &mut Self {
+    pub fn set_sound(&mut self, sound: String) -> &mut Self {
         self.sound = Some(sound);
         self
     }
 }
 
-impl<'a> NotificationBuilder<'a> for WebNotificationBuilder<'a> {
-    fn build(self, device_token: &'a str, options: NotificationOptions<'a>) -> Payload<'a> {
+impl NotificationBuilder for WebNotificationBuilder {
+    fn build(self, device_token: String, options: NotificationOptions) -> Payload {
         Payload {
             aps: APS {
                 alert: Some(APSAlert::WebPush(self.alert)),
@@ -105,13 +105,13 @@ mod tests {
     fn test_webpush_notification() {
         let payload = WebNotificationBuilder::new(
             WebPushAlert {
-                action: "View",
-                title: "Hello",
-                body: "world",
+                action: "View".to_string(),
+                title: "Hello".to_string(),
+                body: "world".to_string(),
             },
-            &["arg1"],
+            vec!["arg1".to_string()],
         )
-        .build("device-token", Default::default())
+        .build("device-token".to_string(), Default::default())
         .to_json_string()
         .unwrap();
 

--- a/src/request/notification/web.rs
+++ b/src/request/notification/web.rs
@@ -70,14 +70,14 @@ impl WebNotificationBuilder {
     /// );
     /// # }
     /// ```
-    pub fn set_sound(&mut self, sound: String) -> &mut Self {
-        self.sound = Some(sound);
+    pub fn set_sound(&mut self, sound: impl Into<String>) -> &mut Self {
+        self.sound = Some(sound.into());
         self
     }
 }
 
 impl NotificationBuilder for WebNotificationBuilder {
-    fn build(self, device_token: String, options: NotificationOptions) -> Payload {
+    fn build(self, device_token: impl Into<String>, options: NotificationOptions) -> Payload {
         Payload {
             aps: APS {
                 alert: Some(APSAlert::WebPush(self.alert)),
@@ -88,7 +88,7 @@ impl NotificationBuilder for WebNotificationBuilder {
                 mutable_content: None,
                 url_args: Some(self.url_args),
             },
-            device_token,
+            device_token: device_token.into(),
             options,
             data: BTreeMap::new(),
         }

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -8,18 +8,18 @@ use std::fmt::Debug;
 
 /// The data and options for a push notification.
 #[derive(Debug, Clone, Serialize)]
-pub struct Payload<'a> {
+pub struct Payload {
     /// Send options
     #[serde(skip)]
-    pub options: NotificationOptions<'a>,
+    pub options: NotificationOptions,
     /// The token for the receiving device
     #[serde(skip)]
-    pub device_token: &'a str,
+    pub device_token: String,
     /// The pre-defined notification payload
-    pub aps: APS<'a>,
+    pub aps: APS,
     /// Application specific payload
     #[serde(flatten)]
-    pub data: BTreeMap<&'a str, Value>,
+    pub data: BTreeMap<String, Value>,
 }
 
 /// Object that can be serialized to create an APNS request.
@@ -35,12 +35,12 @@ pub struct Payload<'a> {
 ///
 /// async fn send() -> Result<(), Box<dyn std::error::Error>> {
 ///     let builder = DefaultNotificationBuilder::new()
-///         .set_body("Hi there")
+///         .set_body("Hi there".to_owned())
 ///         .set_badge(420)
-///         .set_category("cat1")
-///         .set_sound("ping.flac");
+///         .set_category("cat1".to_owned())
+///         .set_sound("ping.flac".to_owned());
 ///
-///     let payload = builder.build("device-token-from-the-user", Default::default());
+///     let payload = builder.build("device-token-from-the-user".to_owned(), Default::default());
 ///     let mut file = File::open("/path/to/private_key.p8")?;
 ///
 ///     let client = Client::token(&mut file, "KEY_ID", "TEAM_ID", ClientConfig::default()).unwrap();
@@ -51,18 +51,18 @@ pub struct Payload<'a> {
 /// }
 ///
 /// #[derive(Serialize, Debug)]
-/// struct Payload<'a> {
-///     aps: APS<'a>,
+/// struct Payload {
+///     aps: APS,
 ///     my_custom_value: String,
 ///     #[serde(skip_serializing)]
-///     options: NotificationOptions<'a>,
+///     options: NotificationOptions,
 ///     #[serde(skip_serializing)]
-///     device_token: &'a str,
+///     device_token: String,
 /// }
 ///
-/// impl<'a> PayloadLike for Payload<'a> {
-///     fn get_device_token(&self) -> &'a str {
-///         self.device_token
+/// impl PayloadLike for Payload {
+///     fn get_device_token(&self) -> String {
+///         self.device_token.to_owned()
 ///     }
 ///     fn get_options(&self) -> &NotificationOptions {
 ///         &self.options
@@ -78,15 +78,15 @@ pub trait PayloadLike: serde::Serialize + Debug {
     }
 
     /// Returns token for the device
-    fn get_device_token(&self) -> &str;
+    fn get_device_token(&self) -> String;
 
     /// Gets [`NotificationOptions`] for this Payload.
     fn get_options(&self) -> &NotificationOptions;
 }
 
-impl<'a> PayloadLike for Payload<'a> {
-    fn get_device_token(&self) -> &'a str {
-        self.device_token
+impl PayloadLike for Payload {
+    fn get_device_token(&self) -> String {
+        self.device_token.clone()
     }
 
     fn get_options(&self) -> &NotificationOptions {
@@ -94,7 +94,7 @@ impl<'a> PayloadLike for Payload<'a> {
     }
 }
 
-impl<'a> Payload<'a> {
+impl Payload {
     /// Client-specific custom data to be added in the payload.
     /// The `root_key` defines the JSON key in the root of the request
     /// data, and `data` the object containing custom data. The `data`
@@ -111,11 +111,11 @@ impl<'a> Payload<'a> {
     /// # fn main() {
     /// let mut payload = DefaultNotificationBuilder::new()
     ///     .set_content_available()
-    ///     .build("token", Default::default());
+    ///     .build("token".to_owned(), Default::default());
     /// let mut custom_data = HashMap::new();
     ///
     /// custom_data.insert("foo", "bar");
-    /// payload.add_custom_data("foo_data", &custom_data).unwrap();
+    /// payload.add_custom_data("foo_data".to_owned(), &custom_data).unwrap();
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"content-available\":1,\"mutable-content\":0},\"foo_data\":{\"foo\":\"bar\"}}",
@@ -133,15 +133,15 @@ impl<'a> Payload<'a> {
     /// fn main() {
     /// #[derive(Serialize)]
     /// struct CompanyData {
-    ///     foo: &'static str,
+    ///     foo: String,
     /// }
     ///
     /// let mut payload = DefaultNotificationBuilder::new()
     ///     .set_content_available()
-    ///     .build("token", Default::default());
-    /// let mut custom_data = CompanyData { foo: "bar" };
+    ///     .build("token".to_owned(), Default::default());
+    /// let mut custom_data = CompanyData { foo: "bar".to_owned() };
     ///
-    /// payload.add_custom_data("foo_data", &custom_data).unwrap();
+    /// payload.add_custom_data("foo_data".to_owned(), &custom_data).unwrap();
     ///
     /// assert_eq!(
     ///     "{\"aps\":{\"content-available\":1,\"mutable-content\":0},\"foo_data\":{\"foo\":\"bar\"}}",
@@ -149,7 +149,7 @@ impl<'a> Payload<'a> {
     /// );
     /// }
     /// ```
-    pub fn add_custom_data(&mut self, root_key: &'a str, data: &dyn Serialize) -> Result<&mut Self, Error> {
+    pub fn add_custom_data(&mut self, root_key: String, data: &dyn Serialize) -> Result<&mut Self, Error> {
         self.data.insert(root_key, serde_json::to_value(data)?);
 
         Ok(self)
@@ -160,10 +160,10 @@ impl<'a> Payload<'a> {
 #[derive(Serialize, Default, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 #[allow(clippy::upper_case_acronyms)]
-pub struct APS<'a> {
+pub struct APS {
     /// The notification content. Can be empty for silent notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub alert: Option<APSAlert<'a>>,
+    pub alert: Option<APSAlert>,
 
     /// A number shown on top of the app icon.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -171,7 +171,7 @@ pub struct APS<'a> {
 
     /// The name of the sound file to play when user receives the notification.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sound: Option<APSSound<'a>>,
+    pub sound: Option<APSSound>,
 
     /// Set to one for silent notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -180,7 +180,7 @@ pub struct APS<'a> {
     /// When a notification includes the category key, the system displays the
     /// actions for that category as buttons in the banner or alert interface.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub category: Option<&'a str>,
+    pub category: Option<String>,
 
     /// If set to one, the app can change the notification content before
     /// displaying it to the user.
@@ -188,27 +188,27 @@ pub struct APS<'a> {
     pub mutable_content: Option<u8>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url_args: Option<&'a [&'a str]>,
+    pub url_args: Option<Vec<String>>,
 }
 
 /// Different notification content types.
 #[derive(Serialize, Debug, Clone)]
 #[serde(untagged)]
-pub enum APSAlert<'a> {
+pub enum APSAlert {
     /// A notification that supports all of the iOS features
-    Default(DefaultAlert<'a>),
+    Default(DefaultAlert),
     /// Safari web push notification
-    WebPush(WebPushAlert<'a>),
+    WebPush(WebPushAlert),
     /// A notification with just a body
-    Body(&'a str),
+    Body(String),
 }
 
 /// Different notification sound types.
 #[derive(Serialize, Debug, Clone)]
 #[serde(untagged)]
-pub enum APSSound<'a> {
+pub enum APSSound {
     /// A critical notification (supported only on >= iOS 12)
-    Critical(DefaultSound<'a>),
+    Critical(DefaultSound),
     /// Name for a notification sound
-    Sound(&'a str),
+    Sound(String),
 }

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -149,8 +149,8 @@ impl Payload {
     /// );
     /// }
     /// ```
-    pub fn add_custom_data(&mut self, root_key: String, data: &dyn Serialize) -> Result<&mut Self, Error> {
-        self.data.insert(root_key, serde_json::to_value(data)?);
+    pub fn add_custom_data(&mut self, root_key: impl Into<String>, data: &dyn Serialize) -> Result<&mut Self, Error> {
+        self.data.insert(root_key.into(), serde_json::to_value(data)?);
 
         Ok(self)
     }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -39,14 +39,14 @@ enum JwtAlg {
 }
 
 #[derive(Serialize, Deserialize)]
-struct JwtHeader<'a> {
+struct JwtHeader {
     alg: JwtAlg,
-    kid: &'a str,
+    kid: String,
 }
 
 #[derive(Serialize, Deserialize)]
-struct JwtPayload<'a> {
-    iss: &'a str,
+struct JwtPayload {
+    iss: String,
     iat: i64,
 }
 
@@ -111,7 +111,7 @@ impl Signer {
 
         let issued_at = get_time();
         let signature = RwLock::new(Signature {
-            key: Self::create_signature(&secret, &key_id, &team_id, issued_at)?,
+            key: Self::create_signature(&secret, key_id.clone(), team_id.clone(), issued_at)?,
             issued_at,
         });
 
@@ -151,7 +151,7 @@ impl Signer {
         Ok(f(&signature.key))
     }
 
-    fn create_signature(secret: &Secret, key_id: &str, team_id: &str, issued_at: i64) -> Result<String, Error> {
+    fn create_signature(secret: &Secret, key_id: String, team_id: String, issued_at: i64) -> Result<String, Error> {
         let headers = JwtHeader {
             alg: JwtAlg::ES256,
             kid: key_id,
@@ -192,7 +192,7 @@ impl Signer {
         let mut signature = self.signature.write();
 
         *signature = Signature {
-            key: Self::create_signature(&self.secret, &self.key_id, &self.team_id, issued_at)?,
+            key: Self::create_signature(&self.secret, self.key_id.clone(), self.team_id.clone(), issued_at)?,
             issued_at,
         };
 


### PR DESCRIPTION
# Description

Switched `&str` in struct attributes to `String`. We will be using this library for our push notification gateway [Hewdig](https://github.com/famedly/hedwig), and those changes would simplify it use, as well as help future users of a2.

Resolves https://github.com/reown-com/a2/issues/67

## How Has This Been Tested?

`cargo test`

## Due Dilligence

* [x] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update